### PR TITLE
이미지 `recordDate` 불일치 처리 FFB-52

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     // 메타데이터 추출용 의존성
-    implementation 'com.drewnoakes:metadata-extractor:2.19.0'
+    implementation 'com.drewnoakes:metadata-extractor:2.18.0'
 
     // SWS S3 SDK 의존성
     implementation 'software.amazon.awssdk:s3:2.20.17'

--- a/src/main/java/com/fivefeeling/memory/domain/media/model/ImageMetadataDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/media/model/ImageMetadataDTO.java
@@ -5,7 +5,7 @@ import java.util.Date;
 public record ImageMetadataDTO(
     Double latitude,
     Double longitude,
-    Date date,
+    Date recordDate,
     String mediaType
 ) {
 

--- a/src/main/java/com/fivefeeling/memory/domain/media/service/MediaProcessingService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/media/service/MediaProcessingService.java
@@ -42,7 +42,7 @@ public class MediaProcessingService {
     mediaFile.setMediaType(metadata.mediaType());
     mediaFile.setMediaLink(uploadResult.getMediaLink());
     mediaFile.setMediaKey(uploadResult.getMediaKey());
-    mediaFile.setRecordDate(metadata.date());
+    mediaFile.setRecordDate(metadata.recordDate());
     mediaFile.setLatitude(metadata.latitude());
     mediaFile.setLongitude(metadata.longitude());
     mediaFileRepository.save(mediaFile);

--- a/src/main/java/com/fivefeeling/memory/domain/media/service/MetadataExtractorService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/media/service/MetadataExtractorService.java
@@ -2,21 +2,18 @@ package com.fivefeeling.memory.domain.media.service;
 
 import com.drew.imaging.ImageMetadataReader;
 import com.drew.metadata.Metadata;
-import com.drew.metadata.exif.ExifIFD0Directory;
 import com.drew.metadata.exif.ExifSubIFDDirectory;
 import com.drew.metadata.exif.GpsDirectory;
 import com.fivefeeling.memory.domain.media.model.ImageMetadataDTO;
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.SimpleDateFormat;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.Date;
-import java.util.TimeZone;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
+@Slf4j
 public class MetadataExtractorService {
 
   public ImageMetadataDTO extractMetadata(MultipartFile file) {
@@ -25,10 +22,9 @@ public class MetadataExtractorService {
 
       Double latitude = null;
       Double longitude = null;
-      Date date = null;
-      String timeZoneOffset = null;
+      Date recordDate = null;
 
-      // GPS 정보와 촬영 날짜 및 타임존 정보를 탐색
+      // GPS 정보
       GpsDirectory gpsDirectory = metadata.getFirstDirectoryOfType(GpsDirectory.class);
       if (gpsDirectory != null && gpsDirectory.getGeoLocation() != null) {
         latitude = gpsDirectory.getGeoLocation().getLatitude();
@@ -37,39 +33,13 @@ public class MetadataExtractorService {
 
       ExifSubIFDDirectory exifDirectory = metadata.getFirstDirectoryOfType(ExifSubIFDDirectory.class);
       if (exifDirectory != null) {
-        date = exifDirectory.getDate(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL);
+        recordDate = exifDirectory.getDate(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL);
       }
-
-      // 타임존 정보 추출
-      ExifIFD0Directory ifd0Directory = metadata.getFirstDirectoryOfType(ExifIFD0Directory.class);
-      if (ifd0Directory != null) {
-        timeZoneOffset = ifd0Directory.getString(ExifIFD0Directory.TAG_DATETIME_ORIGINAL);
-      }
-
-      // 타임존 정보가 있다면 이를 반영하여 정확한 현지 시간으로 변환
-      if (date != null && timeZoneOffset != null) {
-        date = adjustDateWithTimeZone(date, timeZoneOffset);
-      }
-
-      return new ImageMetadataDTO(latitude, longitude, date, file.getContentType());
+      return new ImageMetadataDTO(latitude, longitude, recordDate, file.getContentType());
     } catch (IOException e) {
       throw new RuntimeException("파일을 읽는 중 오류가 발생했습니다.", e);
     } catch (Exception e) {
       throw new RuntimeException("메타데이터를 추출하는 데 실패했습니다.", e);
     }
-  }
-
-  private Date adjustDateWithTimeZone(Date originalDate, String timeZoneOffset) {
-    // 시간대 오프셋을 처리하여 정확한 현지 시간으로 변환
-    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss");
-    dateFormat.setTimeZone(TimeZone.getTimeZone("UTC")); // 기본 UTC로 파싱
-    String formattedDate = dateFormat.format(originalDate);
-
-    // ZonedDateTime으로 변환하여 오프셋 적용
-    ZonedDateTime zonedDateTime = ZonedDateTime.parse(
-        formattedDate + timeZoneOffset,
-        java.time.format.DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ssXXX").withZone(ZoneOffset.UTC)
-    );
-    return Date.from(zonedDateTime.toInstant());
   }
 }

--- a/src/main/java/com/fivefeeling/memory/global/util/DateFormatter.java
+++ b/src/main/java/com/fivefeeling/memory/global/util/DateFormatter.java
@@ -20,17 +20,4 @@ public class DateFormatter {
     return date != null ? SIMPLE_DATE_FORMAT.format(date) : null;
   }
 
-//  // String을 LocalDate로 변환
-//  public static LocalDate parseStringToLocalDate(String date) {
-//    return date != null ? LocalDate.parse(date, DATE_FORMATTER) : null;
-//  }
-//
-//  // String을 Date로 변환 (추가 메서드)
-//  public static Date parseStringToDate(String date) {
-//    try {
-//      return date != null ? SIMPLE_DATE_FORMAT.parse(date) : null;
-//    } catch (Exception e) {
-//      throw new IllegalArgumentException("Invalid date format. Please use yyyy-MM-dd.", e);
-//    }
-//  }
 }


### PR DESCRIPTION
**이슈 설명**
- 원본 데이터의 정확한 촬영 일자가 잘못 추출되거나, 타임존 보정이 제대로 이루어지지 않는 문제가 있었습니다. 
- 이 문제는 특정 이미지 파일에서 타임존 정보를 반영하지 못하는 상황에서 발생했습니다. 
- 이를 해결하기 위해 코드를 수정하여 타임존 처리를 간소화하고, 촬영 일자를 간단하게 추출하는 방식으로 개선했습니다.

**Fix 사항**:
1. **타임존 처리 제거**
   - 기존 코드에서는 `ExifIFD0Directory`에서 타임존 정보를 추출하여 촬영 일자에 적용하는 방식을 사용했으나, 타임존 정보가 누락되거나 잘못된 경우 보정이 어려웠습니다.
   - 타임존 처리 관련 코드를 삭제하고, 촬영 일자(`TAG_DATETIME_ORIGINAL`)만 간단하게 추출하는 방식으로 변경했습니다.

2. **시간 보정 로직 제거**
   - `adjustDateWithTimeZone` 메서드에서 수행하던 시간 보정 로직을 삭제하여, 타임존 없이 촬영 시간을 단순하게 가져오도록 처리했습니다.

3. **코드 간소화**
   - 타임존 보정 없이 메타데이터에서 바로 촬영 일자를 가져와 `recordDate`에 저장하도록 하여 코드 구조를 간결하게 만들었습니다.

4. **GPS 정보는 유지**
   - GPS 좌표 추출에 대한 코드는 그대로 유지하여 위도와 경도를 추출합니다.
   
   This close #57 

