### PR TITLE
공유 상태 업데이트 FFB-67

### DIFF
--- a/src/main/java/com/fivefeeling/memory/domain/share/controller/ShareController.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/controller/ShareController.java
@@ -3,6 +3,7 @@ package com.fivefeeling.memory.domain.share.controller;
 import com.fivefeeling.memory.domain.share.dto.ShareCreateRequestDTO;
 import com.fivefeeling.memory.domain.share.dto.ShareCreateResponseDTO;
 import com.fivefeeling.memory.domain.share.dto.ShareResponseDTO;
+import com.fivefeeling.memory.domain.share.model.ShareStatus;
 import com.fivefeeling.memory.domain.share.service.ShareService;
 import com.fivefeeling.memory.global.common.RestResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,10 +11,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "7. 공유 관련 API")
@@ -36,5 +39,17 @@ public class ShareController {
   @GetMapping("/share/{recipientId}")
   public RestResponse<List<ShareResponseDTO>> getShareInfo(@PathVariable Long recipientId) {
     return RestResponse.success(shareService.getShareById(recipientId));
+  }
+
+  @Operation(summary = "공유요청 수락", description = "<a href='https://www.notion"
+          + ".so/maristadev/17766958e5b3800fa0ecf89667bdaf03?pvs=4' target='_blank'>API 명세서</a>")
+  @PatchMapping("/share/{recipientId}")
+  public RestResponse<ShareResponseDTO> updateShareStatus(
+          @PathVariable Long recipientId,
+          @RequestParam Long shareId,
+          @RequestParam ShareStatus status
+  ) {
+    ShareResponseDTO response = shareService.updateShareStatus(recipientId, shareId, status);
+    return RestResponse.success(response);
   }
 }

--- a/src/main/java/com/fivefeeling/memory/domain/share/model/Share.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/model/Share.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "share")
@@ -36,6 +37,7 @@ public class Share {
   @Column(name = "recipientId", nullable = false)
   private Long recipientId;
 
+  @Setter
   @Column(name = "shareStatus", nullable = false)
   private ShareStatus shareStatus;
 
@@ -58,4 +60,5 @@ public class Share {
   protected void onPreUpdate() {
     this.updatedAt = LocalDateTime.now();
   }
+
 }

--- a/src/main/java/com/fivefeeling/memory/domain/share/repository/ShareRepository.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/repository/ShareRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 public interface ShareRepository extends JpaRepository<Share, Long> {
 
   boolean existsByTripAndRecipientId(Trip trip, Long recipientId);
-  
+
   List<Share> findAllByRecipientId(Long recipientId);
+
 }

--- a/src/main/java/com/fivefeeling/memory/domain/trip/model/Trip.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/model/Trip.java
@@ -11,9 +11,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -60,5 +63,19 @@ public class Trip {
 
   public List<String> getHashtagsAsList() {
     return List.of(this.hashtags.split(","));
+  }
+
+  @ManyToMany
+  @JoinTable(
+          name = "trip_shared_users",
+          joinColumns = @JoinColumn(name = "trip_id"),
+          inverseJoinColumns = @JoinColumn(name = "user_id")
+  )
+  private List<User> sharedUsers = new ArrayList<>();
+
+  public void addSharedUser(User user) {
+    if (!this.sharedUsers.contains(user)) {
+      this.sharedUsers.add(user);
+    }
   }
 }

--- a/src/main/java/com/fivefeeling/memory/domain/trip/repository/TripRepository.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/repository/TripRepository.java
@@ -4,6 +4,7 @@ import com.fivefeeling.memory.domain.trip.model.Trip;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,4 +13,7 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
   List<Trip> findByUserUserId(Long userId);
 
   Optional<Trip> findByTripId(Long tripId);
+
+  @Query("SELECT t FROM Trip t JOIN t.sharedUsers s WHERE s.userId = :userId")
+  List<Trip> findAllBySharedUserId(Long userId);
 }

--- a/src/main/java/com/fivefeeling/memory/domain/trip/repository/TripRepository.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/repository/TripRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,4 +17,13 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
 
   @Query("SELECT t FROM Trip t JOIN t.sharedUsers s WHERE s.userId = :userId")
   List<Trip> findAllBySharedUserId(Long userId);
+
+  @Query("""
+          SELECT DISTINCT t
+          FROM Trip t
+              LEFT JOIN t.sharedUsers su
+          WHERE t.user.userId = :userId
+             OR su.userId = :userId
+          """)
+  List<Trip> findAllAccessibleTrips(@Param("userId") Long userId);
 }

--- a/src/main/java/com/fivefeeling/memory/domain/trip/service/TripQueryService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/service/TripQueryService.java
@@ -24,7 +24,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -50,12 +49,13 @@ public class TripQueryService {
     // 2) 자신이 "공유받은" Trip
     List<Trip> sharedTrips = tripRepository.findAllBySharedUserId(user.getUserId());
 
-    List<Trip> allTrips = new ArrayList<>();
-    allTrips.addAll(ownedTrips);
-    allTrips.addAll(sharedTrips);
+//    List<Trip> allTrips = new ArrayList<>();
+//    allTrips.addAll(ownedTrips);
+//    allTrips.addAll(sharedTrips);
 
 //    List<TripInfoResponseDTO>  = tripRepository.findByUserUserId(user.getUserId()).stream()
-    List<TripInfoResponseDTO> tripDTOs = allTrips.stream()
+    List<TripInfoResponseDTO> tripDTOs = tripRepository.findAllAccessibleTrips(user.getUserId())
+            .stream()
             .map(trip -> new TripInfoResponseDTO(
                     trip.getTripId(),
                     trip.getTripTitle(),

--- a/src/main/java/com/fivefeeling/memory/domain/trip/service/TripQueryService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/service/TripQueryService.java
@@ -24,6 +24,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -42,72 +43,82 @@ public class TripQueryService {
 
   public UserTripInfoResponseDTO getUserTripInfo(String userEmail) {
     User user = userRepository.findByUserEmail(userEmail)
-        .orElseThrow(() -> new CustomException(ResultCode.USER_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ResultCode.USER_NOT_FOUND));
 
-    List<TripInfoResponseDTO> trips = tripRepository.findByUserUserId(user.getUserId()).stream()
-        .map(trip -> new TripInfoResponseDTO(
+    // 1) 자신이 "직접 소유한(내가 만든)" Trip
+    List<Trip> ownedTrips = tripRepository.findByUserUserId(user.getUserId());
+    // 2) 자신이 "공유받은" Trip
+    List<Trip> sharedTrips = tripRepository.findAllBySharedUserId(user.getUserId());
+
+    List<Trip> allTrips = new ArrayList<>();
+    allTrips.addAll(ownedTrips);
+    allTrips.addAll(sharedTrips);
+
+//    List<TripInfoResponseDTO>  = tripRepository.findByUserUserId(user.getUserId()).stream()
+    List<TripInfoResponseDTO> tripDTOs = allTrips.stream()
+            .map(trip -> new TripInfoResponseDTO(
+                    trip.getTripId(),
+                    trip.getTripTitle(),
+                    trip.getCountry(),
+                    formatLocalDateToString(trip.getStartDate()),
+                    formatLocalDateToString(trip.getEndDate()),
+                    trip.getHashtagsAsList(),
+                    List.of()
+            ))
+            .collect(Collectors.toList());
+    return UserTripInfoResponseDTO.withoutPinPoints(
+            user.getUserId(),
+            user.getUserNickName(),
+            tripDTOs);
+  }
+
+
+  public TripInfoResponseDTO getTripById(Long tripId) {
+    Trip trip = tripRepository.findByTripId(tripId)
+            .orElseThrow(() -> new CustomException(ResultCode.TRIP_NOT_FOUND));
+
+    List<MediaFile> mediaFiles = mediaFileRepository.findByTripTripId(tripId);
+
+    List<String> imagesDate = mediaFiles.stream()
+            .map(MediaFile::getRecordDate)
+            .map(LocalDateTime::toLocalDate)
+            .distinct()
+            .sorted()
+            .map(DateFormatter::formatLocalDateToString)
+            .toList();
+
+    return TripInfoResponseDTO.withImagesDate(
             trip.getTripId(),
             trip.getTripTitle(),
             trip.getCountry(),
             formatLocalDateToString(trip.getStartDate()),
             formatLocalDateToString(trip.getEndDate()),
             trip.getHashtagsAsList(),
-            List.of()
-        ))
-        .collect(Collectors.toList());
-    return UserTripInfoResponseDTO.withoutPinPoints(
-        user.getUserId(),
-        user.getUserNickName(),
-        trips);
-  }
-
-
-  public TripInfoResponseDTO getTripById(Long tripId) {
-    Trip trip = tripRepository.findByTripId(tripId)
-        .orElseThrow(() -> new CustomException(ResultCode.TRIP_NOT_FOUND));
-
-    List<MediaFile> mediaFiles = mediaFileRepository.findByTripTripId(tripId);
-
-    List<String> imagesDate = mediaFiles.stream()
-        .map(MediaFile::getRecordDate)
-        .map(LocalDateTime::toLocalDate)
-        .distinct()
-        .sorted()
-        .map(DateFormatter::formatLocalDateToString)
-        .toList();
-
-    return TripInfoResponseDTO.withImagesDate(
-        trip.getTripId(),
-        trip.getTripTitle(),
-        trip.getCountry(),
-        formatLocalDateToString(trip.getStartDate()),
-        formatLocalDateToString(trip.getEndDate()),
-        trip.getHashtagsAsList(),
-        imagesDate
+            imagesDate
     );
   }
 
   public TripResponseDTO getTripInfoById(Long tripId) {
     Trip trip = tripRepository.findById(tripId)
-        .orElseThrow(() -> new CustomException(ResultCode.TRIP_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ResultCode.TRIP_NOT_FOUND));
 
     List<PinPointResponseDTO> pinPoints = pinPointRepository.findEarliestSingleMediaFileForEachPinPointByTripId(tripId);
     List<MediaFileResponseDTO> mediaFiles = pinPointRepository.findMediaFilesByTripId(tripId);
 
     return new TripResponseDTO(
-        trip.getTripTitle(),
-        formatLocalDateToString(trip.getStartDate()),
-        formatLocalDateToString(trip.getEndDate()),
-        pinPoints.stream()
-            .map(pinPoint -> new PinPointResponseDTO(
-                pinPoint.pinPointId(),
-                pinPoint.latitude(),
-                pinPoint.longitude(),
-                pinPoint.recordDate(),
-                pinPoint.mediaLink()
-            ))
-            .collect(Collectors.toList()),
-        mediaFiles
+            trip.getTripTitle(),
+            formatLocalDateToString(trip.getStartDate()),
+            formatLocalDateToString(trip.getEndDate()),
+            pinPoints.stream()
+                    .map(pinPoint -> new PinPointResponseDTO(
+                            pinPoint.pinPointId(),
+                            pinPoint.latitude(),
+                            pinPoint.longitude(),
+                            pinPoint.recordDate(),
+                            pinPoint.mediaLink()
+                    ))
+                    .collect(Collectors.toList()),
+            mediaFiles
     );
   }
 
@@ -131,7 +142,7 @@ public class TripQueryService {
   @Transactional(readOnly = true)
   public PointImageDTO getPointImages(Long tripId, Long pinPointId) {
     PinPoint pinPoint = pinPointRepository.findById(pinPointId)
-        .orElseThrow(() -> new CustomException(ResultCode.PINPOINT_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ResultCode.PINPOINT_NOT_FOUND));
 
     List<MediaFile> mediaFiles = mediaFileRepository.findByTripTripIdAndPinPointPinPointId(tripId, pinPointId);
     if (mediaFiles.isEmpty()) {
@@ -139,39 +150,39 @@ public class TripQueryService {
     }
 
     String startDate = formatLocalDateTimeToString(
-        mediaFiles.stream()
-            .map(MediaFile::getRecordDate)
-            .min(LocalDateTime::compareTo)
-            .orElse(null)
+            mediaFiles.stream()
+                    .map(MediaFile::getRecordDate)
+                    .min(LocalDateTime::compareTo)
+                    .orElse(null)
     );
 
     String endDate = formatLocalDateTimeToString(
-        mediaFiles.stream()
-            .map(MediaFile::getRecordDate)
-            .max(LocalDateTime::compareTo)
-            .orElse(null)
+            mediaFiles.stream()
+                    .map(MediaFile::getRecordDate)
+                    .max(LocalDateTime::compareTo)
+                    .orElse(null)
     );
 
     String firstMediaLink = mediaFiles.get(0).getMediaLink();
 
     List<MediaFileResponseDTO> imagesLink = mediaFiles.stream()
-        .map(file -> MediaFileResponseDTO.mediaFileSummary(
-            file.getMediaLink(),
-            file.getRecordDate()
-        ))
-        .collect(Collectors.toList());
+            .map(file -> MediaFileResponseDTO.mediaFileSummary(
+                    file.getMediaLink(),
+                    file.getRecordDate()
+            ))
+            .collect(Collectors.toList());
 
     MediaFileResponseDTO images = MediaFileResponseDTO.imagesAndFirstImage(
-        firstMediaLink,
-        imagesLink
+            firstMediaLink,
+            imagesLink
     );
     return new PointImageDTO(
-        pinPoint.getPinPointId(),
-        pinPoint.getLatitude(),
-        pinPoint.getLongitude(),
-        startDate,
-        endDate,
-        images
+            pinPoint.getPinPointId(),
+            pinPoint.getLatitude(),
+            pinPoint.getLongitude(),
+            startDate,
+            endDate,
+            images
     );
   }
 
@@ -188,15 +199,15 @@ public class TripQueryService {
       }
 
       List<MediaFileResponseDTO> images = mediaFiles.stream()
-          .map(file -> MediaFileResponseDTO.detailed(
-              file.getMediaFileId(),
-              file.getMediaLink(),
-              file.getMediaType(),
-              file.getRecordDate(),
-              file.getLatitude(),
-              file.getLongitude()
-          ))
-          .collect(Collectors.toList());
+              .map(file -> MediaFileResponseDTO.detailed(
+                      file.getMediaFileId(),
+                      file.getMediaLink(),
+                      file.getMediaType(),
+                      file.getRecordDate(),
+                      file.getLatitude(),
+                      file.getLongitude()
+              ))
+              .collect(Collectors.toList());
 
       return MediaFileResponseDTO.withImages(startOfDay, images);
 


### PR DESCRIPTION
close #93

## Summary by Sourcery

사용자 여행 정보에 공유된 여행을 포함하고 공유 상태를 업데이트할 수 있도록 여행 공유 기능을 업데이트했습니다. TripQueryService를 개선하여 소유한 여행과 공유된 여행을 모두 처리하고, ShareController에 여행의 공유 상태를 업데이트하는 새로운 엔드포인트를 추가했습니다.

새로운 기능:
- 사용자가 공유된 여행 요청을 승인하거나 거부할 수 있도록 여행의 공유 상태를 업데이트하는 기능을 도입했습니다.

개선 사항:
- TripQueryService를 개선하여 사용자와 공유된 여행을 사용자 여행 정보 응답에 포함시켰습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the trip sharing functionality to include shared trips in user trip information and allow updating of share status. Enhance the TripQueryService to handle both owned and shared trips, and add a new endpoint in ShareController to update the share status of a trip.

New Features:
- Introduce functionality to update the share status of a trip, allowing users to approve or reject shared trip requests.

Enhancements:
- Enhance the TripQueryService to include trips shared with the user in the user trip information response.

</details>