### PR TITLE
알림 목록조회 추가 FFB-70

### DIFF
--- a/src/main/java/com/fivefeeling/memory/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/controller/NotificationController.java
@@ -1,0 +1,31 @@
+package com.fivefeeling.memory.domain.notification.controller;
+
+import com.fivefeeling.memory.domain.notification.dto.NotificationResponseDTO;
+import com.fivefeeling.memory.domain.notification.service.NotificationService;
+import com.fivefeeling.memory.global.common.RestResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+@Tag(name = "7. 공유 관련 API")
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  @Operation(summary = "알림 목록 조회", description = "<a href='https://www.notion"
+          + ".so/maristadev/17766958e5b3803690defb16a09d8c88?pvs=4' target='_blank'>API 명세서</a>")
+  @GetMapping("/{userId}")
+  public RestResponse<List<NotificationResponseDTO>> getUnreadNotifications(
+          @PathVariable Long userId
+  ) {
+    return RestResponse.success(notificationService.getUnreadNotifications(userId));
+  }
+}

--- a/src/main/java/com/fivefeeling/memory/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/dto/NotificationResponseDTO.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 public record NotificationResponseDTO(
         Long notificationId,
-        String title,
+        String message,
         String status,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/fivefeeling/memory/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/dto/NotificationResponseDTO.java
@@ -1,0 +1,12 @@
+package com.fivefeeling.memory.domain.notification.dto;
+
+import java.time.LocalDateTime;
+
+public record NotificationResponseDTO(
+        Long notificationId,
+        String title,
+        String status,
+        LocalDateTime createdAt
+) {
+
+}

--- a/src/main/java/com/fivefeeling/memory/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/repository/NotificationRepository.java
@@ -1,8 +1,11 @@
 package com.fivefeeling.memory.domain.notification.repository;
 
 import com.fivefeeling.memory.domain.notification.model.Notification;
+import com.fivefeeling.memory.domain.notification.model.Notification.NotificationStatus;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+  List<Notification> findByUserIdAndStatus(Long userId, NotificationStatus status);
 }

--- a/src/main/java/com/fivefeeling/memory/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/service/NotificationService.java
@@ -1,0 +1,31 @@
+package com.fivefeeling.memory.domain.notification.service;
+
+import com.fivefeeling.memory.domain.notification.dto.NotificationResponseDTO;
+import com.fivefeeling.memory.domain.notification.model.Notification;
+import com.fivefeeling.memory.domain.notification.repository.NotificationRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+
+  public List<NotificationResponseDTO> getUnreadNotifications(Long userId) {
+    List<Notification> notifications = notificationRepository.findByUserIdAndStatus(
+            userId, Notification.NotificationStatus.UNREAD
+    );
+
+    return notifications.stream()
+            .map(notification -> new NotificationResponseDTO(
+                    notification.getNotificationId(),
+                    notification.getMessage(),
+                    notification.getStatus().name(),
+                    notification.getCreatedAt()
+            ))
+            .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
알림 조회 기능 구현
- 알림 컨트롤러 생성 및 API 엔드포인트 추가
- NotificationResponseDTO 정의
- 읽지 않은 알림을 조회하는 서비스 메서드 구현
- 사용자 ID와 상태로 알림을 검색하는 리포지토리 메서드 추가

closes #95

## Summary by Sourcery

새로운 기능:
- 사용자의 읽지 않은 알림을 검색하기 위한 새로운 API 엔드포인트를 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Added a new API endpoint to retrieve unread notifications for a user.

</details>