### PR TITLE
공유 관련 수정

### DIFF
--- a/src/main/java/com/fivefeeling/memory/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/controller/NotificationController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,7 +31,7 @@ public class NotificationController {
     return RestResponse.success(notificationService.getUnreadNotifications(userId));
   }
 
-  @Operation(summary = "알림 상태 변경", description = "<a href='https://www.notion"
+  @Operation(summary = "알림 상태 변경(UNREAD -> READ)", description = "<a href='https://www.notion"
           + ".so/maristadev/18566958e5b3801ea257fcfbe2d9e2e0?pvs=4' target='_blank'>API 명세서</a>")
   @PatchMapping("/{notificationId}")
   public RestResponse<NotificationResponseDTO> markAsRead(
@@ -39,4 +40,15 @@ public class NotificationController {
     return RestResponse.success(notificationService.markAsRead(notificationId));
 
   }
+
+  @Operation(summary = "알림 상태 변경 (READ -> DELETE)",
+          description = "알림 상태가 READ인 경우 DELETE 상태로 변경합니다. 알림 ID 배열을 받아 일괄 처리합니다.")
+  @PatchMapping("/delete")
+  public RestResponse<List<NotificationResponseDTO>> markAsDeleted(
+          @RequestBody List<Long> notificationIds
+  ) {
+    return RestResponse.success(notificationService.markAsDeleted(notificationIds));
+  }
+
+
 }

--- a/src/main/java/com/fivefeeling/memory/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/dto/NotificationResponseDTO.java
@@ -4,9 +4,10 @@ import java.time.LocalDateTime;
 
 public record NotificationResponseDTO(
         Long notificationId,
-        Long shareId,
+        Long referenceId,
         String message,
         String status,
+        String senderNickname,
         LocalDateTime createdAt
 ) {
 

--- a/src/main/java/com/fivefeeling/memory/domain/notification/model/Notification.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/model/Notification.java
@@ -60,4 +60,8 @@ public class Notification {
   public void markAsRead() {
     this.status = NotificationStatus.READ;
   }
+
+  public void markAsDeleted() {
+    this.status = NotificationStatus.DELETE;
+  }
 }

--- a/src/main/java/com/fivefeeling/memory/domain/notification/model/Notification.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/model/Notification.java
@@ -28,7 +28,7 @@ public class Notification {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long notificationId;
 
-  @Column(name = "userId", nullable = false)
+  @Column(name = "user_id", nullable = false)
   private Long userId;
 
   @Column(name = "message", nullable = false)
@@ -40,14 +40,17 @@ public class Notification {
   private NotificationStatus status;
 
   @Setter
-  @Column(name = "streamMessageId")
+  @Column(name = "stream_message_id")
   private String streamMessageId;
 
-  @Column(name = "createdAt", nullable = false, updatable = false)
+  @Column(name = "created_at", nullable = false, updatable = false)
   private LocalDateTime createdAt;
 
-  @Column(name = "shareId")
-  private Long shareId;
+  @Column(name = "reference_id")
+  private Long referenceId;
+
+  @Column(name = "sender_nickname")
+  private String senderNickname;
 
   @PrePersist
   protected void onPersist() {

--- a/src/main/java/com/fivefeeling/memory/domain/notification/model/NotificationStatus.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/model/NotificationStatus.java
@@ -2,5 +2,6 @@ package com.fivefeeling.memory.domain.notification.model;
 
 public enum NotificationStatus {
   UNREAD,
-  READ
+  READ,
+  DELETE
 }

--- a/src/main/java/com/fivefeeling/memory/domain/notification/model/NotificationType.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/model/NotificationType.java
@@ -2,5 +2,6 @@ package com.fivefeeling.memory.domain.notification.model;
 
 public enum NotificationType {
   SHARED_REQUEST,
-  SHARED_APPROVE
+  SHARED_APPROVE,
+  SHARED_REJECTED
 }

--- a/src/main/java/com/fivefeeling/memory/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/service/NotificationService.java
@@ -25,11 +25,13 @@ public class NotificationService {
     List<Notification> notifications = notificationRepository.findByUserId(userId);
 
     return notifications.stream()
+            .filter(notification -> notification.getStatus() != NotificationStatus.DELETE)
             .map(notification -> new NotificationResponseDTO(
                     notification.getNotificationId(),
-                    notification.getShareId(),
+                    notification.getReferenceId(),
                     notification.getMessage().name(),
                     notification.getStatus().name(),
+                    notification.getSenderNickname(),
                     notification.getCreatedAt()
             ))
             .collect(Collectors.toList());
@@ -67,9 +69,10 @@ public class NotificationService {
   private NotificationResponseDTO toDTO(Notification notification) {
     return new NotificationResponseDTO(
             notification.getNotificationId(),
-            notification.getShareId(),
+            notification.getReferenceId(),
             notification.getMessage().toString(),
             notification.getStatus().toString(),
+            notification.getSenderNickname(),
             notification.getCreatedAt()
     );
   }

--- a/src/main/java/com/fivefeeling/memory/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/service/NotificationService.java
@@ -66,6 +66,20 @@ public class NotificationService {
     return toDTO(saved);
   }
 
+
+  public List<NotificationResponseDTO> markAsDeleted(List<Long> notificationIds) {
+    return notificationIds.stream().map(id -> {
+      Notification notification = notificationRepository.findById(id)
+              .orElseThrow(() -> new CustomException(ResultCode.NOTIFICATION_NOT_FOUND));
+
+      if (notification.getStatus() == NotificationStatus.READ) {
+        notification.markAsDeleted();
+        notification = notificationRepository.save(notification);
+      }
+      return toDTO(notification);
+    }).toList();
+  }
+
   private NotificationResponseDTO toDTO(Notification notification) {
     return new NotificationResponseDTO(
             notification.getNotificationId(),

--- a/src/main/java/com/fivefeeling/memory/domain/share/dto/ShareResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/dto/ShareResponseDTO.java
@@ -6,10 +6,14 @@ import lombok.Builder;
 @Builder
 public record ShareResponseDTO(
         Long shareId,
-        Long tripId,
         String tripTitle,
         String ownerNickname,
-        ShareStatus status
+        String recipientNickname,
+        ShareStatus status,
+        String country,
+        String startDate,
+        String endDate,
+        String hashtags
 ) {
 
 }

--- a/src/main/java/com/fivefeeling/memory/domain/share/event/ShareApprovedEvent.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/event/ShareApprovedEvent.java
@@ -14,4 +14,5 @@ public class ShareApprovedEvent {
   private Long shareId;
   private Long tripId;
   private Long ownerId;
+  private String senderNickname;
 }

--- a/src/main/java/com/fivefeeling/memory/domain/share/event/ShareApprovedEventListener.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/event/ShareApprovedEventListener.java
@@ -39,6 +39,8 @@ public class ShareApprovedEventListener {
               .message(NotificationType.SHARED_APPROVE)
               .status(NotificationStatus.UNREAD)
               .streamMessageId(recordId.getValue())
+              .referenceId(event.getShareId())
+              .senderNickname(event.getSenderNickname())
               .build();
       notificationRepository.save(notification);
       log.info("DB에 알림 메시지 저장 완료: {}", notification);

--- a/src/main/java/com/fivefeeling/memory/domain/share/event/ShareCreatedEvent.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/event/ShareCreatedEvent.java
@@ -14,4 +14,5 @@ public class ShareCreatedEvent {
   private Long shareId;
   private Long tripId;
   private Long recipientId;
+  private String senderNickname;
 }

--- a/src/main/java/com/fivefeeling/memory/domain/share/event/ShareCreatedEventListener.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/event/ShareCreatedEventListener.java
@@ -39,7 +39,8 @@ public class ShareCreatedEventListener {
               .message(NotificationType.SHARED_REQUEST)
               .status(NotificationStatus.UNREAD)
               .streamMessageId(recordId.getValue())
-              .shareId(event.getShareId())
+              .referenceId(event.getShareId())
+              .senderNickname(event.getSenderNickname())
               .build();
       notificationRepository.save(notification);
       log.info("DB에 알림 메시지 저장 완료: {}", notification);

--- a/src/main/java/com/fivefeeling/memory/domain/share/event/ShareRejectedEvent.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/event/ShareRejectedEvent.java
@@ -1,0 +1,18 @@
+package com.fivefeeling.memory.domain.share.event;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ShareRejectedEvent {
+
+  private Long shareId;
+  private Long tripId;
+  private Long ownerId;
+  private String senderNickname;
+}

--- a/src/main/java/com/fivefeeling/memory/domain/share/event/ShareRejectedEventListener.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/event/ShareRejectedEventListener.java
@@ -1,0 +1,52 @@
+package com.fivefeeling.memory.domain.share.event;
+
+import com.fivefeeling.memory.domain.notification.model.Notification;
+import com.fivefeeling.memory.domain.notification.model.NotificationStatus;
+import com.fivefeeling.memory.domain.notification.model.NotificationType;
+import com.fivefeeling.memory.domain.notification.repository.NotificationRepository;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ShareRejectedEventListener {
+
+  private final RedisTemplate<String, Object> redisTemplate;
+  private final NotificationRepository notificationRepository;
+
+  @EventListener
+  public void handleShareRejectedEvent(ShareRejectedEvent event) {
+    try {
+      log.info("처리 중인 거절 이벤트: {}", event);
+
+      Map<String, Object> eventMap = Map.of(
+              "recipientId", String.valueOf(event.getOwnerId()),
+              "messageType", NotificationType.SHARED_REJECTED.name()
+      );
+
+      RecordId recordId = redisTemplate.opsForStream().add("shareRequests", eventMap);
+      log.info("Redis Stream에 거절 이벤트 저장 완료: {}", recordId.getValue());
+
+      // 알림 메시지 DB 저장
+      Notification notification = Notification.builder()
+              .userId(event.getOwnerId())
+              .message(NotificationType.SHARED_REJECTED)
+              .status(NotificationStatus.UNREAD)
+              .streamMessageId(recordId.getValue())
+              .referenceId(event.getShareId())
+              .senderNickname(event.getSenderNickname())
+              .build();
+      notificationRepository.save(notification);
+      log.info("DB에 거절 알림 메시지 저장 완료: {}", notification);
+    } catch (Exception e) {
+      log.error("거절 이벤트 처리 중 오류 발생", e);
+    }
+  }
+}

--- a/src/main/java/com/fivefeeling/memory/domain/share/service/ShareService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/service/ShareService.java
@@ -33,6 +33,10 @@ public class ShareService {
     Trip trip = tripRepository.findById(requestDTO.tripId())
             .orElseThrow(() -> new CustomException(ResultCode.TRIP_NOT_FOUND));
 
+    if (trip.getUser().getUserId().equals(requestDTO.recipientId())) {
+      throw new CustomException(ResultCode.CANNOT_SHARE_TO_SELF);
+    }
+
     boolean alreadyRequested = shareRepository.existsByTripAndRecipientId(trip, requestDTO.recipientId());
     if (alreadyRequested) {
       throw new CustomException(ResultCode.SHARE_ALREADY_EXIST);

--- a/src/main/java/com/fivefeeling/memory/domain/share/service/ShareService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/service/ShareService.java
@@ -69,12 +69,19 @@ public class ShareService {
     Share share = shareRepository.findById(shareId)
             .orElseThrow(() -> new CustomException(ResultCode.SHARE_NOT_FOUND));
 
+    User recipient = userRepository.findById(share.getRecipientId())
+            .orElseThrow(() -> new CustomException(ResultCode.USER_NOT_FOUND));
+
     return ShareResponseDTO.builder()
             .shareId(share.getShareId())
-            .tripId(share.getTrip().getTripId())
             .tripTitle(share.getTrip().getTripTitle())
             .ownerNickname(share.getTrip().getUser().getUserNickName())
+            .recipientNickname(recipient.getUserNickName())
             .status(share.getShareStatus())
+            .country(share.getTrip().getCountry())
+            .startDate(share.getTrip().getStartDate().toString())
+            .endDate(share.getTrip().getEndDate().toString())
+            .hashtags(share.getTrip().getHashtags())
             .build();
   }
 
@@ -104,13 +111,19 @@ public class ShareService {
               senderNickname
       ));
     }
+    User recipient = userRepository.findById(share.getRecipientId())
+            .orElseThrow(() -> new CustomException(ResultCode.USER_NOT_FOUND));
 
     return ShareResponseDTO.builder()
             .shareId(share.getShareId())
-            .tripId(share.getTrip().getTripId())
             .tripTitle(share.getTrip().getTripTitle())
             .ownerNickname(share.getTrip().getUser().getUserNickName())
+            .recipientNickname(recipient.getUserNickName())
             .status(share.getShareStatus())
+            .country(share.getTrip().getCountry())
+            .startDate(share.getTrip().getStartDate().toString())
+            .endDate(share.getTrip().getEndDate().toString())
+            .hashtags(share.getTrip().getHashtags())
             .build();
   }
 }

--- a/src/main/java/com/fivefeeling/memory/domain/share/service/ShareService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/service/ShareService.java
@@ -52,7 +52,8 @@ public class ShareService {
     eventPublisher.publishEvent(new ShareCreatedEvent(
             savedShare.getShareId(),
             savedShare.getTrip().getTripId(),
-            savedShare.getRecipientId()
+            savedShare.getRecipientId(),
+            savedShare.getTrip().getUser().getUserNickName()
     ));
 
     return new ShareCreateResponseDTO(
@@ -95,10 +96,12 @@ public class ShareService {
       tripRepository.save(trip);
 
       Long ownerId = trip.getUser().getUserId();
+      String senderNickname = recipient.getUserNickName();
       eventPublisher.publishEvent(new ShareApprovedEvent(
               share.getShareId(),
               trip.getTripId(),
-              ownerId
+              ownerId,
+              senderNickname
       ));
     }
 

--- a/src/main/java/com/fivefeeling/memory/global/common/ResultCode.java
+++ b/src/main/java/com/fivefeeling/memory/global/common/ResultCode.java
@@ -36,33 +36,32 @@ public enum ResultCode {
   USER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT, 3002, "이미 사용 중인 닉네임입니다."),
 
   // 여행 관련 오류 코드 (4000번대)
-  TRIP_NOT_FOUND(HttpStatus.NOT_FOUND, 4000, "해당 여행 정보가 존재하지 않습니다."), TRIP_INFO_LOAD_FAILURE(
-          HttpStatus.INTERNAL_SERVER_ERROR, 4001,
-          "여행 정보를 불러오는 데 실패했습니다. 잠시 후 다시 시도해 주세요."), INVALID_UPDATE_DATA(HttpStatus.BAD_REQUEST, 4002,
-          "유효하지 않은 수정 정보입니다."), PINPOINT_NOT_FOUND(
-          HttpStatus.NOT_FOUND, 4003, "해당 핀포인트가 존재하지 않습니다."), MEDIA_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, 4004,
-          "해당 미디어 파일이 존재하지 않습니다."), INVALID_DATE_FORMAT(
-          HttpStatus.BAD_REQUEST, 4005, "잘못된 날짜 형식입니다. yyyy-MM-dd 형식으로 입력해주세요."), INVALID_COORDINATE(
-          HttpStatus.BAD_REQUEST, 4006, "잘못된 좌표 형식입니다."),
+  TRIP_NOT_FOUND(HttpStatus.NOT_FOUND, 4000, "해당 여행 정보가 존재하지 않습니다."),
+  TRIP_INFO_LOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, 4001, "여행 정보를 불러오는 데 실패했습니다. 잠시 후 다시 시도해 주세요."),
+  INVALID_UPDATE_DATA(HttpStatus.BAD_REQUEST, 4002, "유효하지 않은 수정 정보입니다."),
+  PINPOINT_NOT_FOUND(HttpStatus.NOT_FOUND, 4003, "해당 핀포인트가 존재하지 않습니다."),
+  MEDIA_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, 4004, "해당 미디어 파일이 존재하지 않습니다."),
+  INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, 4005, "잘못된 날짜 형식입니다. yyyy-MM-dd 형식으로 입력해주세요."),
+  INVALID_COORDINATE(HttpStatus.BAD_REQUEST, 4006, "잘못된 좌표 형식입니다."),
 
   // 파일 업로드 및 처리 관련 오류 코드 (5000번대)
-  S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "S3 업로드에 실패했습니다."), FILE_READ_ERROR(
-          HttpStatus.INTERNAL_SERVER_ERROR, 5001,
-          "파일 읽기 중 오류가 발생했습니다."), METADATA_EXTRACTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5002,
-          "메타데이터를 추출하는 데 실패했습니다."), FILE_PROCESSING_ERROR(
-          HttpStatus.INTERNAL_SERVER_ERROR, 5003, "파일 처리 중 오류가 발생했습니다."), FILE_DELETE_FAILED(
-          HttpStatus.INTERNAL_SERVER_ERROR, 5004, "업로드된 파일 삭제에 실패했습니다."),
+  S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "S3 업로드에 실패했습니다."),
+  FILE_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "파일 읽기 중 오류가 발생했습니다."),
+  METADATA_EXTRACTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5002, "메타데이터를 추출하는 데 실패했습니다."),
+  FILE_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5003, "파일 처리 중 오류가 발생했습니다."),
+  FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5004, "업로드된 파일 삭제에 실패했습니다."),
 
   // 날짜별 정보 조회 관련 오류 코드 (6000번대)
   DATE_TRIP_NOT_FOUND(HttpStatus.NOT_FOUND, 6000, "해당 날짜의 여행 정보가 존재하지 않습니다."),
 
   // 위치등록 관련 오류 코드 (7000번대)
-  DATA_NOT_FOUND(HttpStatus.NOT_FOUND, 7000, "해당 tripId의 위도 경도가 없거나 전부 0,0 입니다."), EDIT_DATA_NOT_FOUND(
-          HttpStatus.NOT_FOUND, 7001, "수정할 데이터가 없습니다."),
+  DATA_NOT_FOUND(HttpStatus.NOT_FOUND, 7000, "해당 tripId의 위도 경도가 없거나 전부 0,0 입니다."),
+  EDIT_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, 7001, "수정할 데이터가 없습니다."),
 
   // 공유 관련 오류 코드 (8000번대)
   SHARE_ALREADY_EXIST(HttpStatus.CONFLICT, 8000, "이미 공유된 여행입니다."),
   SHARE_NOT_FOUND(HttpStatus.NOT_FOUND, 8001, "공유된 여행이 없습니다."),
+  CANNOT_SHARE_TO_SELF(HttpStatus.BAD_REQUEST, 8002, "자신에게 공유 요청을 보낼 수 없습니다."),
 
   // 알림 관련 오류 코드 (9000번대)
   NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, 9000, "해당 알림이 존재하지 않습니다.");


### PR DESCRIPTION
This closes #111

## Sourcery 요약

공유 요청 거절 기능 추가, 사용자가 자신에게 여행을 공유하는 것을 방지, 알림 상세 정보 개선을 통해 공유 기능을 개선합니다. 또한 알림을 삭제된 것으로 표시하는 기능도 도입합니다.

새로운 기능:
- 알림을 삭제된 것으로 표시하는 기능을 추가하여 사용자가 이미 읽은 알림을 제거할 수 있습니다.
- 사용자가 자신에게 공유 요청을 보내는 것을 방지하는 검사를 구현합니다.

버그 수정:
- 알림이 상태별로 필터링되지 않아 삭제된 알림이 읽지 않은 알림 목록에 계속 표시되는 버그를 수정합니다.

개선 사항:
- 공유 요청, 승인 및 거절에 대한 알림 페이로드에 보낸 사람의 닉네임을 포함합니다.
- 공유 상세 정보 응답을 개선하여 수신자 닉네임, 국가, 시작 날짜, 종료 날짜 및 해시태그를 포함합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improves the share functionality by adding the ability to reject share requests, preventing users from sharing trips with themselves, and enhancing notification details. It also introduces the ability to mark notifications as deleted.

New Features:
- Adds the ability to mark notifications as deleted, allowing users to remove notifications they have already read.
- Implements a check to prevent users from sending share requests to themselves.

Bug Fixes:
- Fixes a bug where notifications were not being filtered by status, causing deleted notifications to still appear in the unread notifications list.

Enhancements:
- Includes the sender's nickname in the notification payload for share requests, approvals, and rejections.
- Enhances the share detail response to include recipient nickname, country, start date, end date, and hashtags.

</details>