### PR TITLE
여행 정보 조회 API 개선 및 DTO 추가

### DIFF
--- a/src/main/java/com/fivefeeling/memory/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/controller/TripController.java
@@ -8,6 +8,7 @@ import com.fivefeeling.memory.domain.media.model.MediaFileResponseDTO;
 import com.fivefeeling.memory.domain.media.repository.MediaFileRepository;
 import com.fivefeeling.memory.domain.pinpoint.model.PinPoint;
 import com.fivefeeling.memory.domain.pinpoint.service.PinPointService;
+import com.fivefeeling.memory.domain.trip.dto.TripsResponseDTO;
 import com.fivefeeling.memory.domain.trip.model.PointImageDTO;
 import com.fivefeeling.memory.domain.trip.model.Trip;
 import com.fivefeeling.memory.domain.trip.model.TripInfoRequestDTO;
@@ -16,7 +17,6 @@ import com.fivefeeling.memory.domain.trip.model.TripResponseDTO;
 import com.fivefeeling.memory.domain.trip.repository.TripRepository;
 import com.fivefeeling.memory.domain.trip.service.TripManagementService;
 import com.fivefeeling.memory.domain.trip.service.TripQueryService;
-import com.fivefeeling.memory.domain.user.dto.UserTripInfoResponseDTO;
 import com.fivefeeling.memory.global.common.RestResponse;
 import com.fivefeeling.memory.global.common.ResultCode;
 import com.fivefeeling.memory.global.exception.CustomException;
@@ -79,8 +79,8 @@ public class TripController {
   @Tag(name = "2. 여행관리 페이지 API")
   @Operation(summary = "여행관리페이지 사용자의 여행 정보 조회", description = "<a href='https://www.notion"
           + ".so/maristadev/680d29996d0941b9aa742a280e2b3b27?pvs=4' target='_blank'>API 명세서</a>")
-  @GetMapping("/api/trips")
-  public RestResponse<UserTripInfoResponseDTO> getUserTrips(
+  @GetMapping("/v1/trips")
+  public RestResponse<TripsResponseDTO> getUserTrips(
           @RequestHeader("Authorization") String authorizationHeader) {
 
     if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
@@ -91,8 +91,8 @@ public class TripController {
     String token = authorizationHeader.substring(7);
     String userEmail = jwtTokenProvider.getUserEmailFromToken(token);
 
-    UserTripInfoResponseDTO trips = tripQueryService.getUserTripInfo(userEmail);
-    return RestResponse.success(trips);
+    TripsResponseDTO tripsResponse = tripQueryService.getTripsByUserEmail(userEmail);
+    return RestResponse.success(tripsResponse);
   }
 
   @Tag(name = "2. 여행관리 페이지 API")

--- a/src/main/java/com/fivefeeling/memory/domain/trip/dto/TripInfoResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/dto/TripInfoResponseDTO.java
@@ -1,0 +1,16 @@
+package com.fivefeeling.memory.domain.trip.dto;
+
+import java.util.List;
+
+public record TripInfoResponseDTO(
+        Long tripId,
+        String tripTitle,
+        String country,
+        String startDate,
+        String endDate,
+        List<String> hashtags,
+        String ownerNickname,
+        List<String> sharedUsersNicknames
+) {
+
+}

--- a/src/main/java/com/fivefeeling/memory/domain/trip/dto/TripsResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/dto/TripsResponseDTO.java
@@ -1,0 +1,7 @@
+package com.fivefeeling.memory.domain.trip.dto;
+
+import java.util.List;
+
+public record TripsResponseDTO(List<TripInfoResponseDTO> trips) {
+
+}

--- a/src/main/java/com/fivefeeling/memory/domain/trip/service/TripQueryService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/service/TripQueryService.java
@@ -9,12 +9,12 @@ import com.fivefeeling.memory.domain.media.repository.MediaFileRepository;
 import com.fivefeeling.memory.domain.pinpoint.model.PinPoint;
 import com.fivefeeling.memory.domain.pinpoint.model.PinPointResponseDTO;
 import com.fivefeeling.memory.domain.pinpoint.repository.PinPointRepository;
+import com.fivefeeling.memory.domain.trip.dto.TripsResponseDTO;
 import com.fivefeeling.memory.domain.trip.model.PointImageDTO;
 import com.fivefeeling.memory.domain.trip.model.Trip;
 import com.fivefeeling.memory.domain.trip.model.TripInfoResponseDTO;
 import com.fivefeeling.memory.domain.trip.model.TripResponseDTO;
 import com.fivefeeling.memory.domain.trip.repository.TripRepository;
-import com.fivefeeling.memory.domain.user.dto.UserTripInfoResponseDTO;
 import com.fivefeeling.memory.domain.user.model.User;
 import com.fivefeeling.memory.domain.user.repository.UserRepository;
 import com.fivefeeling.memory.global.common.ResultCode;
@@ -40,6 +40,38 @@ public class TripQueryService {
   private final MediaFileRepository mediaFileRepository;
 
 
+  public TripsResponseDTO getTripsByUserEmail(String userEmail) {
+    User user = userRepository.findByUserEmail(userEmail)
+            .orElseThrow(() -> new CustomException(ResultCode.USER_NOT_FOUND));
+
+    List<com.fivefeeling.memory.domain.trip.dto.TripInfoResponseDTO> tripDTOs = tripRepository.findAllAccessibleTrips(
+                    user.getUserId())
+            .stream()
+            .map(trip -> {
+              String ownerNickname = trip.getUser().getUserNickName();
+
+              List<String> sharedUserNicknames = trip.getSharedUsers()
+                      .stream()
+                      .map(User::getUserNickName)
+                      .toList();
+
+              return new com.fivefeeling.memory.domain.trip.dto.TripInfoResponseDTO(
+                      trip.getTripId(),
+                      trip.getTripTitle(),
+                      trip.getCountry(),
+                      formatLocalDateToString(trip.getStartDate()),
+                      formatLocalDateToString(trip.getEndDate()),
+                      trip.getHashtagsAsList(),
+                      ownerNickname,
+                      sharedUserNicknames
+              );
+            })
+            .collect(Collectors.toList());
+    return new TripsResponseDTO(tripDTOs);
+  }
+
+
+/*
   public UserTripInfoResponseDTO getUserTripInfo(String userEmail) {
     User user = userRepository.findByUserEmail(userEmail)
             .orElseThrow(() -> new CustomException(ResultCode.USER_NOT_FOUND));
@@ -72,6 +104,7 @@ public class TripQueryService {
             user.getUserNickName(),
             tripDTOs);
   }
+*/
 
 
   public TripInfoResponseDTO getTripById(Long tripId) {


### PR DESCRIPTION
This closes #121

## Sourcery 요약

여행 정보 검색 API를 개선하고 여행 데이터를 나타내는 새로운 DTO를 도입합니다. 변경 사항에는 엔드포인트를 수정하여 소유자 및 공유 사용자 닉네임과 같은 자세한 정보가 포함된 여행 목록을 반환하고 응답 데이터를 캡슐화하기 위해 새로운 DTO를 도입하는 것이 포함됩니다.

새로운 기능:
- 여행 데이터를 캡슐화하기 위해 `TripsResponseDTO` 및 `TripInfoResponseDTO`를 도입합니다.
- 소유자 및 공유 사용자 닉네임을 포함하여 자세한 정보가 포함된 여행 목록을 검색하는 API 엔드포인트를 노출합니다.
- 소유자 및 공유 사용자 닉네임과 같은 자세한 정보가 포함된 여행 목록을 반환합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improves the trip information retrieval API and introduces new DTOs for representing trip data. The changes include modifying the endpoint to return a list of trips with detailed information such as owner and shared user nicknames, and introducing new DTOs to encapsulate the response data.

New Features:
- Introduces TripsResponseDTO and TripInfoResponseDTO to encapsulate trip data.
- Exposes an API endpoint to retrieve a list of trips with detailed information, including owner and shared user nicknames.
- Returns a list of trips with detailed information such as owner and shared user nicknames

</details>