### PR TITLE
여행 정보 등록 및 응답 메시지 변경

### DIFF
--- a/src/main/java/com/fivefeeling/memory/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/controller/TripController.java
@@ -95,10 +95,10 @@ public class TripController {
   }
 
   @Tag(name = "2. 여행관리 페이지 API")
-  @Operation(summary = "여행 정보 수정", description = "<a href='https://www.notion"
+  @Operation(summary = "여행 정보 최초 등록", description = "<a href='https://www.notion"
           + ".so/maristadev/f928c3dc6c2444c9883b8777eadcefc9?pvs=4' target='_blank'>API 명세서</a>")
   @PutMapping("/api/trips/{tripId}")
-  public RestResponse<TripInfoResponseDTO> updateTrip(
+  public RestResponse<String> updateTrip(
           @RequestHeader("Authorization") String authorizationHeader,
           @PathVariable Long tripId,
           @RequestBody TripInfoRequestDTO tripInfoRequestDTO) {
@@ -111,9 +111,9 @@ public class TripController {
     String token = authorizationHeader.substring(7);
     String userEmail = jwtTokenProvider.getUserEmailFromToken(token);
 
-    TripInfoResponseDTO updatedTrip = tripManagementService.updateTrip(userEmail, tripId, tripInfoRequestDTO);
+    tripManagementService.updateTrip(userEmail, tripId, tripInfoRequestDTO);
 
-    return RestResponse.success(updatedTrip);
+    return RestResponse.success("성공적으로 여행 정보가 등록되었습니다.");
   }
 
   @Tag(name = "2. 여행관리 페이지 API")

--- a/src/main/java/com/fivefeeling/memory/domain/trip/model/TripInfoResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/model/TripInfoResponseDTO.java
@@ -27,25 +27,4 @@ public record TripInfoResponseDTO(
             null, null, null
     );
   }
-
-  public static TripInfoResponseDTO withoutImagesDate(
-          Long tripId,
-          String tripTitle,
-          String country,
-          String startDate,
-          String endDate,
-          List<String> hashtags
-  ) {
-    return new TripInfoResponseDTO(
-            tripId,
-            tripTitle,
-            country,
-            startDate,
-            endDate,
-            hashtags,
-            null,
-            null,
-            null
-    );
-  }
 }

--- a/src/main/java/com/fivefeeling/memory/domain/trip/service/TripManagementService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/service/TripManagementService.java
@@ -1,11 +1,8 @@
 package com.fivefeeling.memory.domain.trip.service;
 
-import static com.fivefeeling.memory.global.util.DateFormatter.formatLocalDateToString;
-
 import com.fivefeeling.memory.domain.media.service.MediaProcessingService;
 import com.fivefeeling.memory.domain.trip.dto.TripInfoRequestDTO;
 import com.fivefeeling.memory.domain.trip.model.Trip;
-import com.fivefeeling.memory.domain.trip.model.TripInfoResponseDTO;
 import com.fivefeeling.memory.domain.trip.repository.TripRepository;
 import com.fivefeeling.memory.domain.user.model.User;
 import com.fivefeeling.memory.domain.user.repository.UserRepository;
@@ -43,7 +40,7 @@ public class TripManagementService {
 
   // 사용자 여행 정보 저장 및 수정
   @Transactional
-  public TripInfoResponseDTO updateTrip(String userEmail, Long tripId, TripInfoRequestDTO tripInfoRequestDTO) {
+  public void updateTrip(String userEmail, Long tripId, TripInfoRequestDTO tripInfoRequestDTO) {
     userRepository.findByUserEmail(userEmail)
             .orElseThrow(() -> new CustomException(ResultCode.USER_NOT_FOUND));
 
@@ -57,15 +54,6 @@ public class TripManagementService {
     trip.setHashtagsFromList(tripInfoRequestDTO.hashtags());
 
     Trip updatedTrip = tripRepository.save(trip);
-
-    return TripInfoResponseDTO.withoutImagesDate(
-            updatedTrip.getTripId(),
-            updatedTrip.getTripTitle(),
-            updatedTrip.getCountry(),
-            formatLocalDateToString(updatedTrip.getStartDate()),
-            formatLocalDateToString(updatedTrip.getEndDate()),
-            updatedTrip.getHashtagsAsList()
-    );
   }
 
   // 사용자 여행 정보 삭제


### PR DESCRIPTION
여행 정보 등록 기능으로 수정
- API 설명을 '여행 정보 최초 등록'으로 변경
- 반환 타입을 문자열로 수정하여 성공 메시지 전달
- 불필요한 DTO 메서드 제거

## Sourcery 요약

여행 정보 등록 API를 수정하여 응답을 단순화하고 문서를 업데이트합니다.

새로운 기능:
- API 응답을 상세한 DTO 대신 성공 메시지 문자열을 반환하도록 변경합니다.

버그 수정:
- 과도하게 복잡한 응답 객체를 생성하는 불필요한 DTO 메서드를 제거합니다.

개선 사항:
- 불필요한 응답 세부 정보를 제거하여 여행 정보 업데이트 방법을 단순화합니다.

문서:
- API 작업 요약을 '초기 여행 정보 등록'으로 명확히 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify trip information registration API to simplify response and update documentation

New Features:
- Change the API response to return a success message string instead of a detailed DTO

Bug Fixes:
- Remove unnecessary DTO method that was creating overly complex response objects

Enhancements:
- Simplify the trip information update method by removing unnecessary response details

Documentation:
- Update API operation summary to clarify it as 'initial trip information registration'

</details>