### PR TITLE
`tripId` 보안 처리

### DIFF
--- a/src/main/java/com/fivefeeling/memory/domain/media/controller/PresignedURLController.java
+++ b/src/main/java/com/fivefeeling/memory/domain/media/controller/PresignedURLController.java
@@ -27,14 +27,14 @@ public class PresignedURLController {
 
   @Operation(summary = "Presigned URL 요청", description = "<a href='https://www.notion"
           + ".so/maristadev/15066958e5b380cb92cec07208539ca8?pvs=4' target='_blank'>API 명세서</a>")
-  @PostMapping("{tripId}/presigned-url")
+  @PostMapping("{tripKey}/presigned-url")
   public RestResponse<FilePresignedResponse> generatePresignedUrl(
-          @PathVariable Long tripId,
+          @PathVariable String tripKey,
           @RequestBody FilePresignedRequest request) {
 
     List<PresignedUrlDetail> presignedUrls = request.files().stream()
             .map(file -> {
-              String fileKey = "upload/" + tripId + "/" + file.fileName();
+              String fileKey = "upload/" + tripKey + "/" + file.fileName();
               String presignedPutUrl = presignedURLService.generatePresignedPutUrl(
                       fileKey, Duration.ofMinutes(10)
               );

--- a/src/main/java/com/fivefeeling/memory/domain/share/controller/ShareController.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/controller/ShareController.java
@@ -9,6 +9,7 @@ import com.fivefeeling.memory.global.common.RestResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,8 +28,10 @@ public class ShareController {
   @Operation(summary = "특정 사용자에게 공유요청", description = "<a href='https://www.notion"
           + ".so/maristadev/17766958e5b380139607e90275d52298?pvs=4' target='_blank'>API 명세서</a>")
   @PostMapping("/v1/trips/share")
-  public RestResponse<ShareCreateResponseDTO> createShare(@RequestBody ShareCreateRequestDTO requestDTO) {
-    return RestResponse.success(shareService.createShare(requestDTO));
+  public RestResponse<ShareCreateResponseDTO> createShare(
+          @AuthenticationPrincipal String userEmail,
+          @RequestBody ShareCreateRequestDTO requestDTO) {
+    return RestResponse.success(shareService.createShare(requestDTO, userEmail));
   }
 
   @Operation(summary = "공유요청 상세조회", description = "<a href='https://www.notion"

--- a/src/main/java/com/fivefeeling/memory/domain/share/dto/ShareCreateRequestDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/dto/ShareCreateRequestDTO.java
@@ -1,7 +1,7 @@
 package com.fivefeeling.memory.domain.share.dto;
 
 public record ShareCreateRequestDTO(
-        Long tripId,
+        String tripKey,
         Long recipientId
 ) {
 

--- a/src/main/java/com/fivefeeling/memory/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/controller/TripController.java
@@ -1,6 +1,7 @@
 package com.fivefeeling.memory.domain.trip.controller;
 
 import com.fivefeeling.memory.domain.media.dto.MediaFilesByDateResponseDTO;
+import com.fivefeeling.memory.domain.trip.converter.TripKeyConverter;
 import com.fivefeeling.memory.domain.trip.dto.MapViewResponseDTO;
 import com.fivefeeling.memory.domain.trip.dto.PinPointImageGalleryResponseDTO;
 import com.fivefeeling.memory.domain.trip.dto.TripCreationResponseDTO;
@@ -34,6 +35,7 @@ public class TripController {
 
   private final TripQueryService tripQueryService;
   private final TripManagementService tripManagementService;
+  private final TripKeyConverter tripKeyConverter;
 
   @Tag(name = "3. 여행등록 페이지 API")
   @Operation(summary = "tripId 임시생성", description = "<a href='https://www.notion"
@@ -48,10 +50,11 @@ public class TripController {
   @Tag(name = "3. 여행등록 페이지 API")
   @Operation(summary = "Trip 최종 확정", description = "<a href='https://www.notion"
           + ".so/maristadev/Trip-1c566958e5b38062b7afd6ed16c69ea1?pvs=4' target='_blank'>API 명세서</a>")
-  @PatchMapping("/{tripId}/finalize")
+  @PatchMapping("/{tripKey}/finalize")
   public RestResponse<String> finalizeTrip(
           @AuthenticationPrincipal String userEmail,
-          @PathVariable("tripId") Long tripId) {
+          @PathVariable("tripKey") String tripKey) {
+    Long tripId = tripKeyConverter.convertToTripId(tripKey);
     tripManagementService.finalizeTrip(userEmail, tripId);
     return RestResponse.success("여행이 성공적으로 등록되었습니다.");
   }
@@ -68,12 +71,13 @@ public class TripController {
   }
 
   @Tag(name = "2. 여행관리 페이지 API")
-  @Operation(summary = "여행정보 수정을 위한 {tripId} 여행정보 조회", description = "<a href='https://www.notion"
+  @Operation(summary = "여행정보 수정을 위한 {tripKey} 여행정보 조회", description = "<a href='https://www.notion"
           + ".so/maristadev/10d66958e5b3803f8dddf7b02d4e83f5?pvs=4' target='_blank'>API 명세서</a>")
-  @GetMapping("/{tripId}")
+  @GetMapping("/{tripKey}")
   public RestResponse<UpdateTripInfoResponseDTO> getTripById(
           @AuthenticationPrincipal String userEmail,
-          @PathVariable Long tripId) {
+          @PathVariable String tripKey) {
+    Long tripId = tripKeyConverter.convertToTripId(tripKey);
     UpdateTripInfoResponseDTO tripInfo = tripQueryService.getTripById(userEmail, tripId);
 
     return RestResponse.success(tripInfo);
@@ -82,12 +86,12 @@ public class TripController {
   @Tag(name = "3. 여행등록 페이지 API")
   @Operation(summary = "여행 정보 최초 등록", description = "<a href='https://www.notion"
           + ".so/maristadev/f928c3dc6c2444c9883b8777eadcefc9?pvs=4' target='_blank'>API 명세서</a>")
-  @PutMapping("/{tripId}")
+  @PutMapping("/{tripKey}")
   public RestResponse<String> updateTrip(
           @AuthenticationPrincipal String userEmail,
-          @PathVariable Long tripId,
+          @PathVariable String tripKey,
           @RequestBody TripInfoRequestDTO tripInfoRequestDTO) {
-
+    Long tripId = tripKeyConverter.convertToTripId(tripKey);
     tripManagementService.updateTrip(userEmail, tripId, tripInfoRequestDTO);
 
     return RestResponse.success("성공적으로 여행 정보가 등록되었습니다.");
@@ -96,11 +100,12 @@ public class TripController {
   @Tag(name = "2. 여행관리 페이지 API")
   @Operation(summary = "여행 정보 삭제", description = "<a href='https://www.notion"
           + ".so/maristadev/38909993a1654e0c9034287a27a483fe?pvs=4' target='_blank'>API 명세서</a>")
-  @DeleteMapping("/{tripId}")
+  @DeleteMapping("/{tripKey}")
   public RestResponse<String> deleteTrip(
           @AuthenticationPrincipal String userEmail,
-          @PathVariable Long tripId) {
+          @PathVariable String tripKey) {
 
+    Long tripId = tripKeyConverter.convertToTripId(tripKey);
     tripManagementService.deleteTrip(userEmail, tripId);
 
     return RestResponse.success("성공적으로 여행 정보가 삭제되었습니다.");
@@ -109,10 +114,11 @@ public class TripController {
   @Tag(name = "5. Map 페이지 API")
   @Operation(summary = "지도위 페이지 여행 정보 조회", description = "<a href='https://www.notion"
           + ".so/maristadev/fc14909a1ec5481ca37b58924637be20?pvs=4' target='_blank'>API 명세서</a>")
-  @GetMapping("/{tripId}/info")
+  @GetMapping("/{tripKey}/info")
   public RestResponse<MapViewResponseDTO> getTripInfo(
           @AuthenticationPrincipal String userEmail,
-          @PathVariable Long tripId) {
+          @PathVariable String tripKey) {
+    Long tripId = tripKeyConverter.convertToTripId(tripKey);
     MapViewResponseDTO tripInfo = tripQueryService.getTripInfoById(userEmail, tripId);
     return RestResponse.success(tripInfo);
   }
@@ -120,12 +126,12 @@ public class TripController {
   @Tag(name = "5. Map 페이지 API")
   @Operation(summary = "핀포인트별 슬라이드 쇼를 위한 이미지 조회", description = "<a href='https://www.notion"
           + ".so/maristadev/d172149814414943866df2f04f409970?pvs=4' target='_blank'>API 명세서</a>")
-  @GetMapping("/{tripId}/pinpoints/{pinPointId}/images")
+  @GetMapping("/{tripKey}/pinpoints/{pinPointId}/images")
   public RestResponse<PinPointImageGalleryResponseDTO> getPointImages(
           @AuthenticationPrincipal String userEmail,
-          @PathVariable Long tripId,
+          @PathVariable String tripKey,
           @PathVariable Long pinPointId) {
-
+    Long tripId = tripKeyConverter.convertToTripId(tripKey);
     PinPointImageGalleryResponseDTO pinPointImageGalleryResponse = tripQueryService.getPointImages(userEmail, tripId,
             pinPointId);
 
@@ -135,12 +141,12 @@ public class TripController {
   @Tag(name = "6. 날짜별 페이지 API")
   @Operation(summary = "날짜별 이미지 조회", description = "<a href='https://www.notion"
           + ".so/maristadev/de630f9fd0424f1ca1d521037730d296?pvs=4' target='_blank'>API 명세서</a>")
-  @GetMapping("/{tripId}/map")
+  @GetMapping("/{tripKey}/map")
   public RestResponse<MediaFilesByDateResponseDTO> getImagesByDate(
           @AuthenticationPrincipal String userEmail,
-          @PathVariable Long tripId,
+          @PathVariable String tripKey,
           @RequestParam String date) {
-
+    Long tripId = tripKeyConverter.convertToTripId(tripKey);
     MediaFilesByDateResponseDTO dateImageDTO = tripQueryService.getImagesByDate(userEmail, tripId, date);
 
     return RestResponse.success(dateImageDTO);

--- a/src/main/java/com/fivefeeling/memory/domain/trip/converter/TripKeyConverter.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/converter/TripKeyConverter.java
@@ -1,0 +1,31 @@
+package com.fivefeeling.memory.domain.trip.converter;
+
+import com.fivefeeling.memory.domain.trip.model.Trip;
+import com.fivefeeling.memory.domain.trip.repository.TripRepository;
+import com.fivefeeling.memory.global.common.ResultCode;
+import com.fivefeeling.memory.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TripKeyConverter {
+
+  private final TripRepository tripRepository;
+
+  /**
+   * 클라이언트로 전달받은 tripKey를 DB에 저장된 tripKey로 변환하는 메서드<br>
+   * 만약 일치하는 Trip이 없다면 403 Forbidden 에러를 발생시킴
+   *
+   * @param tripKey
+   *         클라이언트로부터 전달받은 tripKey
+   * @return DB에 저장된 tripId
+   * @throws CustomException
+   *         UNAUTHORIZED_ACCESS 상태 (403)
+   */
+  public Long convertToTripId(String tripKey) {
+    Trip trip = tripRepository.findByTripKey(tripKey)
+            .orElseThrow(() -> new CustomException(ResultCode.UNAUTHORIZED_ACCESS));
+    return trip.getTripId();
+  }
+}

--- a/src/main/java/com/fivefeeling/memory/domain/trip/dto/TripCreationResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/dto/TripCreationResponseDTO.java
@@ -1,5 +1,5 @@
 package com.fivefeeling.memory.domain.trip.dto;
 
-public record TripCreationResponseDTO(Long tripId) {
+public record TripCreationResponseDTO(String tripKey) {
 
 }

--- a/src/main/java/com/fivefeeling/memory/domain/trip/dto/TripResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/dto/TripResponseDTO.java
@@ -3,7 +3,7 @@ package com.fivefeeling.memory.domain.trip.dto;
 import java.util.List;
 
 public record TripResponseDTO(
-        Long tripId,
+        String tripKey,
         String tripTitle,
         String country,
         String startDate,

--- a/src/main/java/com/fivefeeling/memory/domain/trip/dto/TripSummaryResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/dto/TripSummaryResponseDTO.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record TripSummaryResponseDTO(
-        Long tripId,
+        String tripKey,
         String tripTitle,
         String country,
         LocalDate startDate,

--- a/src/main/java/com/fivefeeling/memory/domain/trip/dto/UpdateTripInfoResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/dto/UpdateTripInfoResponseDTO.java
@@ -3,13 +3,13 @@ package com.fivefeeling.memory.domain.trip.dto;
 import java.util.List;
 
 public record UpdateTripInfoResponseDTO(
-        Long tripId,
+        String tripKey,
         String tripTitle,
         String country,
         String startDate,
         String endDate,
         List<String> hashtags,
-        List<String> meidaFilesDates
+        List<String> mediaFilesDates
 ) {
 
 }

--- a/src/main/java/com/fivefeeling/memory/domain/trip/repository/TripRepository.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/repository/TripRepository.java
@@ -12,8 +12,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TripRepository extends JpaRepository<Trip, Long> {
 
-  Optional<Trip> findByTripId(Long tripId);
-
   // 접근 권한이 있는 여행(소유하거나 공유된 사용자, 상태가 CONFIRMED)만 반환하는 메서드
   @Query("""
           SELECT DISTINCT t
@@ -24,6 +22,8 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
           """)
   Optional<Trip> findAccessibleTrip(@Param("tripId") Long tripId,
                                     @Param("userId") Long userId);
+
+  Optional<Trip> findByTripKey(String tripKey);
 
   @Query("""
           SELECT DISTINCT t

--- a/src/main/java/com/fivefeeling/memory/domain/trip/service/TripManagementService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/service/TripManagementService.java
@@ -42,7 +42,7 @@ public class TripManagementService {
             .build();
 
     tripRepository.save(trip);
-    return new TripCreationResponseDTO(trip.getTripId());
+    return new TripCreationResponseDTO(trip.getTripKey());
   }
 
   @Transactional

--- a/src/main/java/com/fivefeeling/memory/domain/trip/service/TripQueryService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/service/TripQueryService.java
@@ -68,7 +68,7 @@ public class TripQueryService {
                       .toList();
 
               return new TripResponseDTO(
-                      trip.getTripId(),
+                      trip.getTripKey(),
                       trip.getTripTitle(),
                       trip.getCountry(),
                       formatLocalDateToString(trip.getStartDate()),
@@ -81,43 +81,6 @@ public class TripQueryService {
             .collect(Collectors.toList());
     return new TripsResponseDTO(tripDTOs);
   }
-
-
-/*
-  public UserTripInfoResponseDTO getUserTripInfo(String userEmail) {
-    User user = userRepository.findByUserEmail(userEmail)
-            .orElseThrow(() -> new CustomException(ResultCode.USER_NOT_FOUND));
-
-    List<TripInfoResponseDTO> tripDTOs = tripRepository.findAllAccessibleTrips(user.getUserId())
-            .stream()
-            .map(trip -> {
-              String ownerNickname = trip.getUser().getUserNickName();
-
-              List<String> sharedUserNicknames = trip.getSharedUsers()
-                      .stream()
-                      .map(User::getUserNickName)
-                      .toList();
-
-              return TripInfoResponseDTO.withOwnerAndSharedUsers(
-                      trip.getTripId(),
-                      trip.getTripTitle(),
-                      trip.getCountry(),
-                      formatLocalDateToString(trip.getStartDate()),
-                      formatLocalDateToString(trip.getEndDate()),
-                      trip.getHashtagsAsList(),
-                      List.of(),
-                      ownerNickname,
-                      sharedUserNicknames
-              );
-            })
-            .collect(Collectors.toList());
-    return UserTripInfoResponseDTO.withoutPinPoints(
-            user.getUserId(),
-            user.getUserNickName(),
-            tripDTOs);
-  }
-*/
-
 
   public UpdateTripInfoResponseDTO getTripById(String userEmail, Long tripId) {
     Trip trip = tripAccessValidator.validateAccessibleTrip(tripId, userEmail);
@@ -133,7 +96,7 @@ public class TripQueryService {
             .toList();
 
     return new UpdateTripInfoResponseDTO(
-            trip.getTripId(),
+            trip.getTripKey(),
             trip.getTripTitle(),
             trip.getCountry(),
             formatLocalDateToString(trip.getStartDate()),

--- a/src/main/java/com/fivefeeling/memory/domain/user/service/UserService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/user/service/UserService.java
@@ -68,7 +68,7 @@ public class UserService {
 
     TripSummaryResponseDTO tripSummary = tripRepository.findFirstByUserAndStatusOrderByCreatedAtDesc(user, "CONFIRMED")
             .map(recentTrip -> new TripSummaryResponseDTO(
-                    recentTrip.getTripId(),
+                    recentTrip.getTripKey(),
                     recentTrip.getTripTitle(),
                     recentTrip.getCountry(),
                     recentTrip.getStartDate(),

--- a/src/main/java/com/fivefeeling/memory/global/s3/S3UploadService.java
+++ b/src/main/java/com/fivefeeling/memory/global/s3/S3UploadService.java
@@ -33,9 +33,9 @@ public class S3UploadService {
 
     try {
       PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-          .bucket(bucketName)
-          .key(mediaKey)
-          .build();
+              .bucket(bucketName)
+              .key(mediaKey)
+              .build();
       s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));
 
       String mediaLink = "https://" + bucketName + ".s3.amazonaws.com/" + mediaKey;
@@ -53,13 +53,13 @@ public class S3UploadService {
   public void deleteFiles(List<String> mediaKeys) {
     try {
       List<ObjectIdentifier> objects = mediaKeys.stream()
-          .map(key -> ObjectIdentifier.builder().key(key).build())
-          .collect(Collectors.toList());
+              .map(key -> ObjectIdentifier.builder().key(key).build())
+              .collect(Collectors.toList());
 
       DeleteObjectsRequest deleteObjectsRequest = DeleteObjectsRequest.builder()
-          .bucket(bucketName)
-          .delete(Delete.builder().objects(objects).build())
-          .build();
+              .bucket(bucketName)
+              .delete(Delete.builder().objects(objects).build())
+              .build();
 
       s3Client.deleteObjects(deleteObjectsRequest);
     } catch (S3Exception e) {

--- a/src/main/java/com/fivefeeling/memory/global/util/TripKeyGenerator.java
+++ b/src/main/java/com/fivefeeling/memory/global/util/TripKeyGenerator.java
@@ -1,0 +1,27 @@
+package com.fivefeeling.memory.global.util;
+
+import java.security.SecureRandom;
+
+public final class TripKeyGenerator {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+  private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  private static final int KEY_LENGTH = 6;
+
+  private TripKeyGenerator() {
+    // 인스턴스화 방지
+  }
+
+  /**
+   * 6자리 랜덤 문자열을 생성합니다.
+   *
+   * @return 6자리 랜덤 문자열
+   */
+  public static String generateKey() {
+    StringBuilder keyBuilder = new StringBuilder(KEY_LENGTH);
+    for (int i = 0; i < KEY_LENGTH; i++) {
+      keyBuilder.append(CHARACTERS.charAt(RANDOM.nextInt(CHARACTERS.length())));
+    }
+    return keyBuilder.toString();
+  }
+}

--- a/src/main/java/com/fivefeeling/memory/global/util/TripKeyGenerator.java
+++ b/src/main/java/com/fivefeeling/memory/global/util/TripKeyGenerator.java
@@ -5,7 +5,7 @@ import java.security.SecureRandom;
 public final class TripKeyGenerator {
 
   private static final SecureRandom RANDOM = new SecureRandom();
-  private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
   private static final int KEY_LENGTH = 6;
 
   private TripKeyGenerator() {


### PR DESCRIPTION
This closes #141

## Sourcery 요약

직접적인 trip ID 노출을 대체하기 위해 trip key 시스템을 도입하여 trip 식별에 대한 보안을 강화합니다.

새로운 기능:
- trip에 대한 고유한 6자 키를 생성하는 trip key 생성기를 도입했습니다.
- trip 키를 내부 trip ID로 안전하게 변환하는 trip key 변환기를 추가했습니다.

개선 사항:
- 모든 API 엔드포인트에서 Long tripId를 String tripKey로 대체했습니다.
- 보안 trip 키 변환을 처리하기 위해 새로운 TripKeyConverter를 추가했습니다.
- 고유한 trip 키를 생성하기 위해 TripKeyGenerator를 구현했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a security enhancement for trip identification by introducing a trip key system to replace direct trip ID exposure

New Features:
- Introduced a trip key generator to create unique 6-character keys for trips
- Added a trip key converter to securely translate trip keys to internal trip IDs

Enhancements:
- Replaced Long tripId with String tripKey in all API endpoints
- Added a new TripKeyConverter to handle secure trip key translation
- Implemented a TripKeyGenerator to create unique trip keys

</details>