### PR TITLE
refactor: 해시태그 형식을 리스트로 변경

### DIFF
--- a/src/main/java/com/fivefeeling/memory/domain/share/dto/ShareResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/dto/ShareResponseDTO.java
@@ -1,6 +1,7 @@
 package com.fivefeeling.memory.domain.share.dto;
 
 import com.fivefeeling.memory.domain.share.model.ShareStatus;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -13,7 +14,7 @@ public record ShareResponseDTO(
         String country,
         String startDate,
         String endDate,
-        String hashtags
+        List<String> hashtags
 ) {
 
 }

--- a/src/main/java/com/fivefeeling/memory/domain/share/service/ShareService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/share/service/ShareService.java
@@ -87,7 +87,7 @@ public class ShareService {
             .country(share.getTrip().getCountry())
             .startDate(share.getTrip().getStartDate().toString())
             .endDate(share.getTrip().getEndDate().toString())
-            .hashtags(share.getTrip().getHashtags())
+            .hashtags(share.getTrip().getHashtagsAsList())
             .build();
   }
 


### PR DESCRIPTION
해시태그 형식을 리스트로 변경
- DTO에서 해시태그의 타입을 문자열에서 리스트로 수정
- 서비스 로직에서 해시태그를 리스트 형태로 가져오도록 변경

## Sourcery 요약

ShareResponseDTO 및 ShareService에서 해시태그 형식을 단일 문자열 대신 문자열 목록을 사용하도록 리팩터링합니다.

개선 사항:
- ShareResponseDTO에서 해시태그 형식을 문자열에서 문자열 목록으로 변경합니다.
- ShareService를 업데이트하여 해시태그를 문자열 대신 목록으로 검색합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the hashtag format in the ShareResponseDTO and ShareService to use a list of strings instead of a single string.

Enhancements:
- Change the hashtag format in the ShareResponseDTO from a string to a list of strings.
- Update the ShareService to retrieve hashtags as a list instead of a string.

</details>