### PR TITLE
이미지 업로드 완료 상태 업데이트 추가

### DIFF
--- a/src/main/java/com/fivefeeling/memory/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/controller/TripController.java
@@ -48,6 +48,18 @@ public class TripController {
   }
 
   @Tag(name = "3. 여행등록 페이지 API")
+  @Operation(summary = "이미지 업로드 완료 상태 업데이트", description = "<a href='https://www.notion"
+          + ".so/maristadev/1f366958e5b38030b6a0f62a2eeef8ab?pvs=4' target='_blank'>API 명세서</a>")
+  @PatchMapping("/{tripKey}/images-uploaded")
+  public RestResponse<String> markImagesUploaded(
+          @AuthenticationPrincipal String userEmail,
+          @PathVariable("tripKey") String tripKey) {
+    Long tripId = tripKeyConverter.convertToTripId(tripKey);
+    tripManagementService.markImagesUploaded(userEmail, tripId);
+    return RestResponse.success("이미지 업로드 완료 상태로 변경되었습니다.");
+  }
+
+  @Tag(name = "3. 여행등록 페이지 API")
   @Operation(summary = "Trip 최종 확정", description = "<a href='https://www.notion"
           + ".so/maristadev/Trip-1c566958e5b38062b7afd6ed16c69ea1?pvs=4' target='_blank'>API 명세서</a>")
   @PatchMapping("/{tripKey}/finalize")

--- a/src/main/java/com/fivefeeling/memory/domain/trip/dto/TripResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/dto/TripResponseDTO.java
@@ -11,7 +11,8 @@ public record TripResponseDTO(
         List<String> hashtags,
         String ownerNickname,
         List<String> sharedUsersNicknames,
-        Long shareId
+        Long shareId,
+        Boolean confirmed
 ) {
 
 }

--- a/src/main/java/com/fivefeeling/memory/domain/trip/model/Trip.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/model/Trip.java
@@ -7,6 +7,8 @@ import com.fivefeeling.memory.global.util.TripKeyGenerator;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -59,8 +61,9 @@ public class Trip {
   @Column(name = "hashtags", length = 255)
   private String hashtags;
 
+  @Enumerated(EnumType.STRING)
   @Column(name = "status")
-  private String status;
+  private TripStatus status;
 
   @Column(name = "created_at", updatable = false)
   private LocalDateTime createdAt;

--- a/src/main/java/com/fivefeeling/memory/domain/trip/model/TripStatus.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/model/TripStatus.java
@@ -1,0 +1,7 @@
+package com.fivefeeling.memory.domain.trip.model;
+
+public enum TripStatus {
+  DRAFT,
+  IMAGES_UPLOADED,
+  CONFIRMED
+}

--- a/src/main/java/com/fivefeeling/memory/domain/trip/repository/TripRepository.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/repository/TripRepository.java
@@ -30,7 +30,7 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
           FROM Trip t
               LEFT JOIN t.sharedUsers su
           WHERE (t.user.userId = :userId OR su.userId = :userId)
-                    AND t.status = 'CONFIRMED'
+                    AND t.status = 'CONFIRMED' OR t.status = 'IMAGES_UPLOADED'
           """)
   List<Trip> findAllAccessibleTrips(@Param("userId") Long userId);
 

--- a/src/main/java/com/fivefeeling/memory/domain/trip/service/TripQueryService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/trip/service/TripQueryService.java
@@ -19,6 +19,7 @@ import com.fivefeeling.memory.domain.trip.dto.TripResponseDTO;
 import com.fivefeeling.memory.domain.trip.dto.TripsResponseDTO;
 import com.fivefeeling.memory.domain.trip.dto.UpdateTripInfoResponseDTO;
 import com.fivefeeling.memory.domain.trip.model.Trip;
+import com.fivefeeling.memory.domain.trip.model.TripStatus;
 import com.fivefeeling.memory.domain.trip.repository.TripRepository;
 import com.fivefeeling.memory.domain.trip.validator.TripAccessValidator;
 import com.fivefeeling.memory.domain.user.model.User;
@@ -63,6 +64,7 @@ public class TripQueryService {
                     user.getUserId())
             .stream()
             .map(trip -> {
+              boolean confirmed = trip.getStatus() == TripStatus.CONFIRMED;
               String ownerNickname = trip.getUser().getUserNickName();
 
               List<String> sharedUserNicknames = trip.getSharedUsers()
@@ -84,7 +86,8 @@ public class TripQueryService {
                       trip.getHashtagsAsList(),
                       ownerNickname,
                       sharedUserNicknames,
-                      shareId
+                      shareId,
+                      confirmed
               );
             })
             .collect(Collectors.toList());


### PR DESCRIPTION
This Closes #148

## Sourcery 요약

상태 관리를 위해 TripStatus enum을 사용하고, 이미지를 업로드됨으로 표시하는 엔드포인트를 추가하며, 올바른 상태 전환을 적용하고, 여행 응답에서 확인 상태를 노출합니다.

새로운 기능:
- 여행 라이프사이클 상태(DRAFT, IMAGES_UPLOADED, CONFIRMED)를 나타내는 TripStatus enum을 도입합니다.
- 여행 상태를 IMAGES_UPLOADED로 업데이트하는 markImagesUploaded 서비스 메서드와 PATCH /{tripKey}/images-uploaded 엔드포인트를 추가합니다.

개선 사항:
- Trip.status를 String에서 JPA @Enumerated 매핑이 있는 TripStatus enum으로 변환합니다.
- CONFIRMED로 전환하기 전에 finalizeTrip에서 IMAGES_UPLOADED 상태를 적용합니다.
- 접근 가능한 여행 저장소 쿼리에 IMAGES_UPLOADED 상태를 포함합니다.
- TripResponseDTO에 confirmed boolean을 추가하고 여행 쿼리 서비스에서 이를 채웁니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use a TripStatus enum for status management, add an endpoint to mark images as uploaded, enforce correct state transitions, and expose confirmation status in trip responses

New Features:
- Introduce TripStatus enum to represent trip lifecycle states (DRAFT, IMAGES_UPLOADED, CONFIRMED)
- Add markImagesUploaded service method and PATCH /{tripKey}/images-uploaded endpoint to update trip status to IMAGES_UPLOADED

Enhancements:
- Convert Trip.status from String to TripStatus enum with JPA @Enumerated mapping
- Enforce IMAGES_UPLOADED state in finalizeTrip before transitioning to CONFIRMED
- Include IMAGES_UPLOADED status in accessible trips repository query
- Add confirmed boolean to TripResponseDTO and populate it in trip query service

</details>