### PR TITLE
알림 기능 개선 및 사용자 프로필 수정

### DIFF
--- a/src/main/java/com/fivefeeling/memory/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/fivefeeling/memory/domain/notification/repository/NotificationRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-  List<Notification> findByUserIdAndStatus(Long userId, NotificationStatus status);
-
   List<Notification> findByUserId(Long userId);
+
+  long countByUserIdAndStatus(Long userId, NotificationStatus status);
 }

--- a/src/main/java/com/fivefeeling/memory/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/fivefeeling/memory/domain/user/controller/UserProfileController.java
@@ -4,7 +4,6 @@ import com.fivefeeling.memory.domain.user.dto.UpdateNickNameRequest;
 import com.fivefeeling.memory.domain.user.dto.UserSummaryResponseDTO;
 import com.fivefeeling.memory.domain.user.service.UserService;
 import com.fivefeeling.memory.global.common.RestResponse;
-import com.fivefeeling.memory.global.util.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +24,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserProfileController {
 
   private final UserService userService;
-  private final JwtTokenProvider jwtTokenProvider;
 
   @Operation(summary = "사용자 요약 정보 조회", description = "<a href='https://www.notion"
           + ".so/maristadev/1ca66958e5b380478db5da52e40aa8d8?pvs=4' target='_blank'>API 명세서</a>")

--- a/src/main/java/com/fivefeeling/memory/domain/user/dto/UserSummaryResponseDTO.java
+++ b/src/main/java/com/fivefeeling/memory/domain/user/dto/UserSummaryResponseDTO.java
@@ -1,12 +1,10 @@
 package com.fivefeeling.memory.domain.user.dto;
 
-import com.fivefeeling.memory.domain.trip.dto.TripSummaryResponseDTO;
-
 public record UserSummaryResponseDTO(
         Long userId,
         String nickname,
         long tripsCount,
-        TripSummaryResponseDTO recentTrip
+        long unreadNotificationsCount
 ) {
 
 }

--- a/src/main/java/com/fivefeeling/memory/domain/user/service/UserService.java
+++ b/src/main/java/com/fivefeeling/memory/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.fivefeeling.memory.domain.user.service;
 
-import com.fivefeeling.memory.domain.trip.dto.TripSummaryResponseDTO;
+import com.fivefeeling.memory.domain.notification.model.NotificationStatus;
+import com.fivefeeling.memory.domain.notification.repository.NotificationRepository;
 import com.fivefeeling.memory.domain.trip.model.TripStatus;
 import com.fivefeeling.memory.domain.trip.repository.TripRepository;
 import com.fivefeeling.memory.domain.user.dto.UserSearchResponseDTO;
@@ -20,6 +21,7 @@ public class UserService {
 
   private final UserRepository userRepository;
   private final TripRepository tripRepository;
+  private final NotificationRepository notificationRepository;
 
   public void updateUserNickNameByEmail(String userEmail, String userNickName) {
     User user = userRepository.findByUserEmail(userEmail.trim().toLowerCase())
@@ -67,22 +69,14 @@ public class UserService {
 
     long tripsCount = tripRepository.countByUserAndStatus(user, TripStatus.CONFIRMED);
 
-    TripSummaryResponseDTO tripSummary = tripRepository.findFirstByUserAndStatusOrderByCreatedAtDesc(user,
-                    TripStatus.CONFIRMED)
-            .map(recentTrip -> new TripSummaryResponseDTO(
-                    recentTrip.getTripKey(),
-                    recentTrip.getTripTitle(),
-                    recentTrip.getCountry(),
-                    recentTrip.getStartDate(),
-                    recentTrip.getEndDate(),
-                    recentTrip.getHashtagsAsList()))
-            .orElse(null);
+    long unreadNotificationCount = notificationRepository.countByUserIdAndStatus(user.getUserId(),
+            NotificationStatus.UNREAD);
 
     return new UserSummaryResponseDTO(
             user.getUserId(),
             user.getUserNickName(),
             tripsCount,
-            tripSummary
+            unreadNotificationCount
     );
   }
 }


### PR DESCRIPTION
알림 카운트 기능 추가와 사용자 프로필 수정
- 사용자의 읽지 않은 알림 개수를 반환하는 기능 추가
- 사용자 요약 정보에서 최근 여행 관련 데이터 제거
- 불필요한 JwtTokenProvider 제거

## Sourcery 요약

사용자 프로필 요약에 읽지 않은 알림 개수를 포함하고, 불필요한 여행 데이터 및 JWT 제공자 종속성을 정리합니다.

새로운 기능:
- 사용자 요약에 읽지 않은 알림 개수를 포함하는 엔드포인트 지원을 추가합니다.

개선 사항:
- `UserSummaryResponseDTO`에서 최근 여행 세부 정보를 읽지 않은 알림 개수로 대체합니다.

잡일:
- `UserProfileController`에서 사용하지 않는 `JwtTokenProvider`를 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Include unread notification count in user profile summary and clean up obsolete trip data and JWT provider dependencies

New Features:
- Add endpoint support to include unread notification count in user summary

Enhancements:
- Replace recent trip details with unread notification count in UserSummaryResponseDTO

Chores:
- Remove unused JwtTokenProvider from UserProfileController

</details>