### PR TITLE
게스트 스케줄러 안정성 개선 및 배치 삭제 최적화

### DIFF
--- a/src/main/java/com/triptyche/backend/domain/media/repository/MediaFileRepository.java
+++ b/src/main/java/com/triptyche/backend/domain/media/repository/MediaFileRepository.java
@@ -8,9 +8,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface MediaFileRepository extends JpaRepository<MediaFile, Long> {
@@ -87,4 +89,9 @@ public interface MediaFileRepository extends JpaRepository<MediaFile, Long> {
   );
 
   List<MediaFile> findAllByTripIn(List<Trip> trips);
+
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM MediaFile m WHERE m.trip IN :trips")
+  void deleteAllByTripIn(@Param("trips") List<Trip> trips);
 }

--- a/src/main/java/com/triptyche/backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/triptyche/backend/domain/notification/repository/NotificationRepository.java
@@ -4,10 +4,19 @@ import com.triptyche.backend.domain.notification.model.Notification;
 import com.triptyche.backend.domain.notification.model.NotificationStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
   List<Notification> findByUserIdAndStatusNot(Long userId, NotificationStatus status);
 
   long countByUserIdAndStatus(Long userId, NotificationStatus status);
+
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM Notification n WHERE n.userId IN :userIds")
+  void deleteAllByUserIdIn(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/triptyche/backend/domain/share/repository/ShareRepository.java
+++ b/src/main/java/com/triptyche/backend/domain/share/repository/ShareRepository.java
@@ -6,9 +6,11 @@ import com.triptyche.backend.domain.trip.model.Trip;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface ShareRepository extends JpaRepository<Share, Long> {
@@ -17,7 +19,10 @@ public interface ShareRepository extends JpaRepository<Share, Long> {
 
   List<Share> findAllByRecipientId(Long recipientId);
 
-  void deleteAllByTripIn(List<Trip> trips);
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM Share s WHERE s.trip IN :trips")
+  void deleteAllByTripIn(@Param("trips") List<Trip> trips);
 
   @Query("""
       SELECT s FROM Share s

--- a/src/main/java/com/triptyche/backend/domain/trip/repository/PinPointRepository.java
+++ b/src/main/java/com/triptyche/backend/domain/trip/repository/PinPointRepository.java
@@ -3,12 +3,15 @@ package com.triptyche.backend.domain.trip.repository;
 import com.triptyche.backend.domain.media.dto.MediaFileResponseDTO;
 import com.triptyche.backend.domain.trip.dto.PinPointResponse;
 import com.triptyche.backend.domain.trip.model.PinPoint;
+import com.triptyche.backend.domain.trip.model.Trip;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface PinPointRepository extends JpaRepository<PinPoint, Long> {
 
@@ -50,6 +53,11 @@ public interface PinPointRepository extends JpaRepository<PinPoint, Long> {
   List<PinPointResponse> findEarliestSingleMediaFileForEachPinPointByTripId(
           @Param("tripId") Long tripId,
           @Param("defaultDate") LocalDateTime defaultDate);
+
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM PinPoint p WHERE p.trip IN :trips")
+  void deleteAllByTripIn(@Param("trips") List<Trip> trips);
 
   @Query("""
               SELECT new com.triptyche.backend.domain.media.dto.MediaFileResponseDTO(

--- a/src/main/java/com/triptyche/backend/domain/trip/repository/TripRepository.java
+++ b/src/main/java/com/triptyche/backend/domain/trip/repository/TripRepository.java
@@ -7,9 +7,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface TripRepository extends JpaRepository<Trip, Long> {
@@ -63,4 +65,14 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
   List<Trip> findSoftDeletedBefore(@Param("threshold") LocalDateTime threshold);
 
   List<Trip> findAllByUserIn(List<User> users);
+
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM Trip t WHERE t.user IN :users")
+  void deleteAllByUserIn(@Param("users") List<User> users);
+
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM Trip t WHERE t IN :trips")
+  void deleteAllIn(@Param("trips") List<Trip> trips);
 }

--- a/src/main/java/com/triptyche/backend/domain/trip/scheduler/TripCleanupExecutor.java
+++ b/src/main/java/com/triptyche/backend/domain/trip/scheduler/TripCleanupExecutor.java
@@ -1,9 +1,9 @@
 package com.triptyche.backend.domain.trip.scheduler;
 
-import com.triptyche.backend.domain.media.model.MediaFile;
 import com.triptyche.backend.domain.media.repository.MediaFileRepository;
 import com.triptyche.backend.domain.share.repository.ShareRepository;
 import com.triptyche.backend.domain.trip.model.Trip;
+import com.triptyche.backend.domain.trip.repository.PinPointRepository;
 import com.triptyche.backend.domain.trip.repository.TripRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,18 +19,22 @@ public class TripCleanupExecutor {
   private final TripRepository tripRepository;
   private final ShareRepository shareRepository;
   private final MediaFileRepository mediaFileRepository;
+  private final PinPointRepository pinPointRepository;
 
   @Transactional
   public void deleteAbandonedTrips(List<Trip> trips) {
-    tripRepository.deleteAll(trips);
+    mediaFileRepository.deleteAllByTripIn(trips);
+    pinPointRepository.deleteAllByTripIn(trips);
+    tripRepository.deleteAllIn(trips);
     log.info("방치된 여행 삭제 완료 — {}건", trips.size());
   }
 
   @Transactional
-  public void deleteSoftDeletedTrips(List<Trip> trips, List<MediaFile> mediaFiles) {
+  public void deleteSoftDeletedTrips(List<Trip> trips) {
     shareRepository.deleteAllByTripIn(trips);
-    mediaFileRepository.deleteAll(mediaFiles);
-    tripRepository.deleteAll(trips);
+    mediaFileRepository.deleteAllByTripIn(trips);
+    pinPointRepository.deleteAllByTripIn(trips);
+    tripRepository.deleteAllIn(trips);
     log.info("만료된 여행 영구 삭제 완료 — {}건", trips.size());
   }
 }

--- a/src/main/java/com/triptyche/backend/domain/trip/scheduler/TripCleanupScheduler.java
+++ b/src/main/java/com/triptyche/backend/domain/trip/scheduler/TripCleanupScheduler.java
@@ -56,12 +56,11 @@ public class TripCleanupScheduler {
       return;
     }
 
-    List<MediaFile> mediaFiles = mediaFileRepository.findAllByTripIn(deletedTrips);
-    List<String> mediaKeys = mediaFiles.stream()
+    List<String> mediaKeys = mediaFileRepository.findAllByTripIn(deletedTrips).stream()
             .map(MediaFile::getMediaKey)
             .toList();
 
-    cleanupExecutor.deleteSoftDeletedTrips(deletedTrips, mediaFiles);
+    cleanupExecutor.deleteSoftDeletedTrips(deletedTrips);
     deleteFromStorage(mediaKeys);
   }
 

--- a/src/main/java/com/triptyche/backend/domain/user/dto/OAuthUserInfo.java
+++ b/src/main/java/com/triptyche/backend/domain/user/dto/OAuthUserInfo.java
@@ -3,14 +3,13 @@ package com.triptyche.backend.domain.user.dto;
 import com.triptyche.backend.domain.user.model.User;
 import java.util.List;
 
-public record UserDTO(
+public record OAuthUserInfo(
         String userName,
         String userEmail,
         String provider,
-        List<String> roles // 권한 정보 추가
+        List<String> roles
 ) {
 
-  // User 엔티티로 변환하는 메서드
   public User toEntity() {
     return User.builder()
             .userName(this.userName())

--- a/src/main/java/com/triptyche/backend/domain/user/model/User.java
+++ b/src/main/java/com/triptyche/backend/domain/user/model/User.java
@@ -19,6 +19,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
@@ -28,6 +29,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@ToString(exclude = {"trips"})
 public class User {
 
   @Id

--- a/src/main/java/com/triptyche/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/triptyche/backend/domain/user/repository/UserRepository.java
@@ -21,8 +21,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByUserNickName(String userNickName);
 
-  List<User> findByUserId(Long userId);
-
   List<User> findByRoleAndCreatedAtBefore(UserRole role, LocalDateTime threshold);
 
   @Transactional

--- a/src/main/java/com/triptyche/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/triptyche/backend/domain/user/repository/UserRepository.java
@@ -6,6 +6,10 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
@@ -20,4 +24,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
   List<User> findByUserId(Long userId);
 
   List<User> findByRoleAndCreatedAtBefore(UserRole role, LocalDateTime threshold);
+
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM User u WHERE u.userId IN :userIds")
+  void deleteAllByUserIdIn(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/triptyche/backend/domain/user/scheduler/GuestCleanupExecutor.java
+++ b/src/main/java/com/triptyche/backend/domain/user/scheduler/GuestCleanupExecutor.java
@@ -1,0 +1,56 @@
+package com.triptyche.backend.domain.user.scheduler;
+
+import com.triptyche.backend.domain.media.model.MediaFile;
+import com.triptyche.backend.domain.media.repository.MediaFileRepository;
+import com.triptyche.backend.domain.notification.repository.NotificationRepository;
+import com.triptyche.backend.domain.share.repository.ShareRepository;
+import com.triptyche.backend.domain.trip.model.Trip;
+import com.triptyche.backend.domain.trip.repository.PinPointRepository;
+import com.triptyche.backend.domain.trip.repository.TripRepository;
+import com.triptyche.backend.domain.user.model.User;
+import com.triptyche.backend.domain.user.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GuestCleanupExecutor {
+
+    private final UserRepository userRepository;
+    private final TripRepository tripRepository;
+    private final ShareRepository shareRepository;
+    private final MediaFileRepository mediaFileRepository;
+    private final PinPointRepository pinPointRepository;
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    public List<String> deleteExpiredGuests(List<User> expiredGuests) {
+        List<Long> userIds = expiredGuests.stream().map(User::getUserId).toList();
+        // @SQLRestriction 적용 — soft-delete된 게스트 Trip의 S3 키는 수집 제외 (기존 동작 유지)
+        List<Trip> allTrips = tripRepository.findAllByUserIn(expiredGuests);
+
+        List<String> s3Keys = allTrips.isEmpty() ? List.of() :
+                mediaFileRepository.findAllByTripIn(allTrips).stream()
+                        .map(MediaFile::getMediaKey)
+                        .filter(key -> !key.startsWith("demo/"))
+                        .toList();
+
+        // DB 삭제 순서 (FK 제약 준수)
+        notificationRepository.deleteAllByUserIdIn(userIds);
+        if (!allTrips.isEmpty()) {
+            shareRepository.deleteAllByTripIn(allTrips);
+            mediaFileRepository.deleteAllByTripIn(allTrips);
+            pinPointRepository.deleteAllByTripIn(allTrips);
+            // JPQL bulk delete — @SQLRestriction 우회, soft-deleted Trip도 포함 삭제 (의도된 동작)
+            tripRepository.deleteAllByUserIn(expiredGuests);
+        }
+        userRepository.deleteAllByUserIdIn(userIds);
+
+        log.info("만료된 게스트 계정 정리 완료 — {}건", expiredGuests.size());
+        return s3Keys;
+    }
+}

--- a/src/main/java/com/triptyche/backend/domain/user/scheduler/GuestCleanupScheduler.java
+++ b/src/main/java/com/triptyche/backend/domain/user/scheduler/GuestCleanupScheduler.java
@@ -1,8 +1,5 @@
 package com.triptyche.backend.domain.user.scheduler;
 
-import com.triptyche.backend.domain.media.repository.MediaFileRepository;
-import com.triptyche.backend.domain.trip.model.Trip;
-import com.triptyche.backend.domain.trip.repository.TripRepository;
 import com.triptyche.backend.domain.user.model.User;
 import com.triptyche.backend.domain.user.model.UserRole;
 import com.triptyche.backend.domain.user.repository.UserRepository;
@@ -13,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
@@ -21,14 +17,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class GuestCleanupScheduler {
 
     private final UserRepository userRepository;
-    private final TripRepository tripRepository;
-    private final MediaFileRepository mediaFileRepository;
+    private final GuestCleanupExecutor guestCleanupExecutor;
     private final S3UploadService s3UploadService;
 
     private static final int GUEST_SESSION_HOURS = 4;
 
-    @Scheduled(cron = "0 0 * * * *") // 매 정시 실행
-    @Transactional
+    @Scheduled(cron = "0 0 * * * *")
     public void cleanupExpiredGuests() {
         LocalDateTime threshold = LocalDateTime.now().minusHours(GUEST_SESSION_HOURS);
         List<User> expiredGuests = userRepository.findByRoleAndCreatedAtBefore(UserRole.GUEST, threshold);
@@ -38,28 +32,17 @@ public class GuestCleanupScheduler {
             return;
         }
 
-        // 전체 게스트의 Trip을 한 번에 조회 (N+1 방지)
-        List<Trip> allTrips = tripRepository.findAllByUserIn(expiredGuests);
+        List<String> s3Keys = guestCleanupExecutor.deleteExpiredGuests(expiredGuests);
+        deleteFromStorage(s3Keys);
+    }
 
-        // 전체 Trip의 MediaFile을 한 번에 조회 후 S3 삭제 (demo/ 경로 제외)
-        if (!allTrips.isEmpty()) {
-            List<String> deletableKeys = mediaFileRepository.findAllByTripIn(allTrips).stream()
-                    .map(mf -> mf.getMediaKey())
-                    .filter(key -> !key.startsWith("demo/"))
-                    .toList();
-
-            if (!deletableKeys.isEmpty()) {
-                try {
-                    s3UploadService.deleteFiles(deletableKeys);
-                } catch (Exception e) {
-                    log.error("게스트 S3 파일 삭제 실패: {}건", deletableKeys.size(), e);
-                }
-            }
-
-            tripRepository.deleteAll(allTrips);
+    private void deleteFromStorage(List<String> s3Keys) {
+        if (s3Keys.isEmpty()) return;
+        try {
+            s3UploadService.deleteFiles(s3Keys);
+            log.info("게스트 S3 파일 정리 완료 — {}건", s3Keys.size());
+        } catch (Exception e) {
+            log.error("게스트 S3 파일 정리 실패 — {}건, 수동 확인 필요", s3Keys.size(), e);
         }
-
-        userRepository.deleteAll(expiredGuests);
-        log.info("만료된 게스트 계정 정리 완료 — {}건", expiredGuests.size());
     }
 }

--- a/src/main/java/com/triptyche/backend/global/oauth/OAuthAttributes.java
+++ b/src/main/java/com/triptyche/backend/global/oauth/OAuthAttributes.java
@@ -1,6 +1,6 @@
 package com.triptyche.backend.global.oauth;
 
-import com.triptyche.backend.domain.user.dto.UserDTO;
+import com.triptyche.backend.domain.user.dto.OAuthUserInfo;
 import com.triptyche.backend.global.common.ResultCode;
 import com.triptyche.backend.global.exception.CustomException;
 import java.util.Arrays;
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 public enum OAuthAttributes {
-  GOOGLE("google", (attribute) -> new UserDTO(
+  GOOGLE("google", (attribute) -> new OAuthUserInfo(
           (String) attribute.get("name"),
           (String) attribute.get("email"),
           "google",
@@ -37,7 +37,7 @@ public enum OAuthAttributes {
       nickname = "사용자";
     }
 
-    return new UserDTO(
+    return new OAuthUserInfo(
             nickname,
             email,
             "kakao",
@@ -46,14 +46,14 @@ public enum OAuthAttributes {
   });
 
   private final String registrationId;
-  private final Function<Map<String, Object>, UserDTO> of;
+  private final Function<Map<String, Object>, OAuthUserInfo> of;
 
-  OAuthAttributes(String registrationId, Function<Map<String, Object>, UserDTO> of) {
+  OAuthAttributes(String registrationId, Function<Map<String, Object>, OAuthUserInfo> of) {
     this.registrationId = registrationId;
     this.of = of;
   }
 
-  public static UserDTO extract(String registrationId, Map<String, Object> attributes) {
+  public static OAuthUserInfo extract(String registrationId, Map<String, Object> attributes) {
     return Arrays.stream(values())
             .filter(value -> registrationId.equals(value.registrationId))
             .findFirst()

--- a/src/main/java/com/triptyche/backend/global/oauth/service/OAuth2Service.java
+++ b/src/main/java/com/triptyche/backend/global/oauth/service/OAuth2Service.java
@@ -1,6 +1,6 @@
 package com.triptyche.backend.global.oauth.service;
 
-import com.triptyche.backend.domain.user.dto.UserDTO;
+import com.triptyche.backend.domain.user.dto.OAuthUserInfo;
 import com.triptyche.backend.domain.user.model.User;
 import com.triptyche.backend.domain.user.repository.UserRepository;
 import com.triptyche.backend.global.common.ResultCode;
@@ -50,7 +50,7 @@ public class OAuth2Service implements OAuth2UserService<OAuth2UserRequest, OAuth
               .getUserNameAttributeName();
 
       Map<String, Object> attributes = oAuth2User.getAttributes();
-      UserDTO userProfile = OAuthAttributes.extract(registrationId, attributes);
+      OAuthUserInfo userProfile = OAuthAttributes.extract(registrationId, attributes);
 
       User user = updateOrSaveUser(userProfile);
       Long userId = user.getUserId();
@@ -90,7 +90,7 @@ public class OAuth2Service implements OAuth2UserService<OAuth2UserRequest, OAuth
           String registrationId,
           String userNameAttributeName,
           Map<String, Object> attributes,
-          UserDTO userProfile) {
+          OAuthUserInfo userProfile) {
     Map<String, Object> customAttribute = new HashMap<>();
     customAttribute.put(userNameAttributeName, attributes.get(userNameAttributeName));
     customAttribute.put("provider", registrationId);
@@ -99,7 +99,7 @@ public class OAuth2Service implements OAuth2UserService<OAuth2UserRequest, OAuth
     return customAttribute;
   }
 
-  private User updateOrSaveUser(UserDTO userProfile) {
+  private User updateOrSaveUser(OAuthUserInfo userProfile) {
     try {
       // 이메일과 제공자 정보를 기준으로 사용자 검색
       Optional<User> existingUser = userRepository.findUserByUserEmailAndProvider(userProfile.userEmail(),


### PR DESCRIPTION
## 📌 변경 사항 개요

- `GuestCleanupScheduler`를 `TripCleanupScheduler/Executor` 패턴에 맞게 재구성하여 S3 외부 I/O를 트랜잭션 범위 밖으로 분리
- 배치 컨텍스트(`GuestCleanupExecutor`, `TripCleanupExecutor`)의 `deleteAll(List)` → JPQL bulk delete로 교체하여 쿼리 수 최적화
- 게스트 정리 시 `Share`, `Notification` 고아 레코드 누락 문제 해결

## 🛠 주요 변경 사항

1. [신규] `GuestCleanupExecutor` 생성 — `@Transactional` DB 삭제 전담, S3 key 목록 반환
2. [리팩토링] `GuestCleanupScheduler` — `@Transactional` 제거, Executor에 DB 삭제 위임, S3 삭제를 트랜잭션 종료 후 처리
3. [리팩토링] `TripCleanupExecutor` — `deleteAll(List)` → bulk delete(`deleteAllIn`, `deleteAllByTripIn`) 교체
4. [추가] `TripRepository`, `MediaFileRepository`, `PinPointRepository`, `ShareRepository`, `UserRepository`, `NotificationRepository` — `@Modifying @Query` bulk delete 메서드 추가

## 📋 작업 상세 내용

**S3 I/O 트랜잭션 분리**
- 기존 `GuestCleanupScheduler`는 `@Transactional` 내부에서 S3 삭제를 호출. 
- S3 응답 대기 시간만큼 DB 커넥션이 점유, S3 타임아웃 시 DB 트랜잭션 전체가 롤백되는 구조. 
- Executor 패턴으로 분리하여 DB 커밋 완료 후 S3 삭제가 실행되도록 변경.

**배치 bulk delete 적용**
- `deleteAll(List)`은 JPA가 엔티티를 건별로 DELETE하는 방식, 
- 게스트 10명/Trip 30개 기준 약 43회 쿼리가 발생. 
- `@Modifying @Query` bulk delete로 교체하여 쿼리 수를 약 6회 고정으로 줄였다. 
- FK 제약에 따른 삭제 순서: `Notification → Share → MediaFile → PinPoint → Trip → User`

