### PR TITLE
feat: Trip 조회 API — ?view=summary 쿼리 파라미터로 지구본/티켓 응답 분리

### DIFF
--- a/src/main/java/com/triptyche/backend/domain/trip/controller/TripQueryController.java
+++ b/src/main/java/com/triptyche/backend/domain/trip/controller/TripQueryController.java
@@ -4,6 +4,7 @@ import com.triptyche.backend.domain.media.dto.MediaByDateResponse;
 import com.triptyche.backend.domain.trip.dto.PinPointMediaListResponse;
 import com.triptyche.backend.domain.trip.dto.TripListResponse;
 import com.triptyche.backend.domain.trip.dto.TripMapResponse;
+import com.triptyche.backend.domain.trip.dto.TripSummaryListResponse;
 import com.triptyche.backend.domain.trip.dto.TripUpdateResponse;
 import com.triptyche.backend.domain.guest.service.GuestShareTriggerService;
 import com.triptyche.backend.domain.trip.facade.TripFacade;
@@ -29,10 +30,14 @@ public class TripQueryController {
   private final GuestShareTriggerService guestShareTriggerService;
 
   @Tag(name = "2. 여행관리 페이지 API")
-  @Operation(summary = "여행관리페이지 사용자의 여행 정보 조회", description = "<a href='https://www.notion"
-          + ".so/maristadev/680d29996d0941b9aa742a280e2b3b27?pvs=4' target='_blank'>API 명세서</a>")
+  @Operation(summary = "여행 목록 조회", description = "view=summary: 지구본용 5개 필드 / 기본: 티켓용 전체 필드")
   @GetMapping
-  public RestResponse<TripListResponse> getUserTrips(@CurrentUser User user) {
+  public RestResponse<?> getUserTrips(
+          @CurrentUser User user,
+          @RequestParam(required = false) String view) {
+    if ("summary".equals(view)) {
+      return RestResponse.success(tripFacade.getTripsSummary(user));
+    }
     RestResponse<TripListResponse> response = RestResponse.success(tripFacade.getTripsByUser(user));
     if (user.getRole() == UserRole.GUEST) {
       guestShareTriggerService.triggerIfNeeded(user.getUserId());

--- a/src/main/java/com/triptyche/backend/domain/trip/dto/TripSummaryListResponse.java
+++ b/src/main/java/com/triptyche/backend/domain/trip/dto/TripSummaryListResponse.java
@@ -1,0 +1,5 @@
+package com.triptyche.backend.domain.trip.dto;
+
+import java.util.List;
+
+public record TripSummaryListResponse(List<TripSummaryResponse> trips) {}

--- a/src/main/java/com/triptyche/backend/domain/trip/dto/TripSummaryResponse.java
+++ b/src/main/java/com/triptyche/backend/domain/trip/dto/TripSummaryResponse.java
@@ -1,15 +1,9 @@
 package com.triptyche.backend.domain.trip.dto;
 
-import java.time.LocalDate;
-import java.util.List;
-
 public record TripSummaryResponse(
         String tripKey,
         String tripTitle,
         String country,
-        LocalDate startDate,
-        LocalDate endDate,
-        List<String> hashtags
-) {
-
-}
+        String startDate,
+        String endDate
+) {}

--- a/src/main/java/com/triptyche/backend/domain/trip/facade/TripFacade.java
+++ b/src/main/java/com/triptyche/backend/domain/trip/facade/TripFacade.java
@@ -14,6 +14,8 @@ import com.triptyche.backend.domain.trip.dto.PinPointResponse;
 import com.triptyche.backend.domain.trip.dto.TripDetailResponse;
 import com.triptyche.backend.domain.trip.dto.TripListResponse;
 import com.triptyche.backend.domain.trip.dto.TripMapResponse;
+import com.triptyche.backend.domain.trip.dto.TripSummaryListResponse;
+import com.triptyche.backend.domain.trip.dto.TripSummaryResponse;
 import com.triptyche.backend.domain.trip.dto.TripUpdateResponse;
 import com.triptyche.backend.domain.trip.model.PinPoint;
 import com.triptyche.backend.domain.trip.model.Trip;
@@ -92,6 +94,22 @@ public class TripFacade {
             .toList();
 
     return new TripListResponse(tripDetails);
+  }
+
+  public TripSummaryListResponse getTripsSummary(User user) {
+    List<Trip> trips = tripRepository.findAllAccessibleTripsWithOwner(user.getUserId());
+
+    List<TripSummaryResponse> summaries = trips.stream()
+            .map(trip -> new TripSummaryResponse(
+                    trip.getTripKey(),
+                    trip.getTripTitle(),
+                    trip.getCountry(),
+                    formatLocalDateToString(trip.getStartDate()),
+                    formatLocalDateToString(trip.getEndDate())
+            ))
+            .toList();
+
+    return new TripSummaryListResponse(summaries);
   }
 
   public TripUpdateResponse getTripById(User user, String tripKey) {


### PR DESCRIPTION
## 📌 변경 사항 개요

- `GET /v1/trips` 하나를 지구본·티켓 페이지가 공유하던 구조를 쿼리 파라미터로 분리
- `?view=summary` 호출 시 5개 필드만 반환, GUEST 공유 트리거 미실행

## 🛠 주요 변경 사항

1. [신규] `TripSummaryResponse` (5개 필드, String 날짜) / `TripSummaryListResponse` DTO 추가
2. [신규] `TripFacade.getTripsSummary()` — Share JOIN 없이 5개 필드 매핑
3. [수정] `TripQueryController.getUserTrips()` — `?view=summary` 분기 추가, `RestResponse<?>` 반환

## 📋 작업 상세 내용

| 엔드포인트 | 응답 | GUEST 트리거 |
|---|---|---|
| `GET /v1/trips` | 전체 필드 (`TripListResponse`) | O |
| `GET /v1/trips?view=summary` | 5개 필드 (`TripSummaryListResponse`) | X |
| `GET /v1/trips?view=<기타>` | 전체 필드 (fallback) | O |

- DB 변경 없음 / 새 의존성 없음
- `findAllAccessibleTripsWithOwner()` 재사용 — 공유받은 여행도 지구본에 표시됨

## ✅ 체크리스트

- [x] 코드 리뷰어가 확인해야 할 중요한 부분이 있습니까?
- [ ] 테스트는 작성되었습니까?
- [ ] 문서는 업데이트되었습니까?