### PR TITLE
이미지 업로드 v2 파이프라인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,7 @@ CLAUDE.md
 .omc/
 
 /doc/**
+
+# Python (image-worker)
+__pycache__/
+*.pyc

--- a/image-worker/main.py
+++ b/image-worker/main.py
@@ -39,6 +39,7 @@ OCI_BUCKET_NAME = os.environ["OCI_BUCKET_NAME"]
 
 STREAM_KEY = "image-processing-stream"
 DLQ_KEY = "image-processing-dlq"
+PROCESSED_STREAM_KEY = "media-processed-stream"
 CONSUMER_GROUP = "image-workers"
 CONSUMER_NAME = "worker-1"
 MAX_RETRY = 3
@@ -114,6 +115,12 @@ def move_to_dlq(r: redis.Redis, message_id: str, fields: dict, reason: str):
         r.xadd(DLQ_KEY, {**fields, "failed_reason": reason, "original_id": message_id})
         r.xack(STREAM_KEY, CONSUMER_GROUP, message_id)
         log.error("DLQ 이동 — mediaFileId: %s, reason: %s", fields.get("mediaFileId"), reason)
+
+        if fields.get("flow") == "v2" and "mediaFileId" in fields:
+            try:
+                publish_failed_result(r, int(fields["mediaFileId"]), reason)
+            except Exception as ex:
+                log.error("[v2] DLQ FAILED 결과 발행 실패 — error: %s", ex)
     except Exception as e:
         log.error("DLQ 이동 실패 — message_id: %s, error: %s", message_id, e)
 
@@ -161,6 +168,60 @@ def delete_original(s3, original_key: str):
         log.info("원본 삭제 완료 — key: %s", original_key)
     except Exception as e:
         log.warning("원본 삭제 실패 (무시) — key: %s, error: %s", original_key, e)
+
+
+def publish_processed_result(r: redis.Redis, media_file_id: int, final_key: str, processed_at: str):
+    try:
+        r.xadd(PROCESSED_STREAM_KEY, {
+            "mediaFileId": str(media_file_id),
+            "finalKey": final_key,
+            "processedAt": processed_at,
+        })
+        log.info("[v2] 결과 발행 완료 — mediaFileId: %d", media_file_id)
+    except Exception as e:
+        log.error("[v2] 결과 발행 실패 — mediaFileId: %d, error: %s", media_file_id, e)
+
+
+def publish_failed_result(r: redis.Redis, media_file_id: int, reason: str):
+    try:
+        r.xadd(PROCESSED_STREAM_KEY, {
+            "mediaFileId": str(media_file_id),
+            "status": "FAILED",
+            "reason": reason,
+        })
+        log.warning("[v2] 실패 결과 발행 — mediaFileId: %d, reason: %s", media_file_id, reason)
+    except Exception as e:
+        log.error("[v2] 실패 결과 발행 실패 — mediaFileId: %d, error: %s", media_file_id, e)
+
+
+def process_message_v2(s3, fields: dict) -> tuple:
+    """v2 흐름. 변환본 PUT만 수행 — DB/원본 삭제는 BE 위임.
+    반환: (media_file_id, final_key, processed_at_iso)
+    """
+    from datetime import datetime, timezone
+
+    media_file_id = int(fields["mediaFileId"])
+    temp_key = fields["tempKey"]
+    final_key = fields["finalKey"]
+
+    log.info("[v2] 처리 시작 — mediaFileId: %d, tempKey: %s", media_file_id, temp_key)
+
+    response = s3.get_object(Bucket=OCI_BUCKET_NAME, Key=temp_key)
+    image_bytes = response["Body"].read()
+    webp_bytes = resize_and_convert(image_bytes)
+
+    s3.put_object(
+        Bucket=OCI_BUCKET_NAME,
+        Key=final_key,
+        Body=webp_bytes,
+        ContentType="image/webp",
+        ContentLength=len(webp_bytes),
+    )
+
+    processed_at = datetime.now(timezone.utc).isoformat()
+
+    log.info("[v2] 변환 완료 — mediaFileId: %d, finalKey: %s", media_file_id, final_key)
+    return media_file_id, final_key, processed_at
 
 
 def process_message(s3, message_id: str, fields: dict):
@@ -228,10 +289,16 @@ def main():
                             continue
 
                         try:
-                            original_key = process_message(s3, message_id, fields)
-                            r.xack(STREAM_KEY, CONSUMER_GROUP, message_id)
-                            # XACK 이후 원본 삭제
-                            delete_original(s3, original_key)
+                            flow = fields.get("flow", "v1")
+                            if flow == "v2":
+                                media_file_id, final_key, processed_at = process_message_v2(s3, fields)
+                                r.xack(STREAM_KEY, CONSUMER_GROUP, message_id)
+                                publish_processed_result(r, media_file_id, final_key, processed_at)
+                            else:
+                                original_key = process_message(s3, message_id, fields)
+                                r.xack(STREAM_KEY, CONSUMER_GROUP, message_id)
+                                # XACK 이후 원본 삭제
+                                delete_original(s3, original_key)
 
                         except ClientError as e:
                             log.error("OCI 오류 — message_id: %s, error: %s", message_id, e)

--- a/src/main/java/com/triptyche/backend/domain/media/controller/MediaMetadataController.java
+++ b/src/main/java/com/triptyche/backend/domain/media/controller/MediaMetadataController.java
@@ -8,6 +8,7 @@ import com.triptyche.backend.domain.media.dto.MediaUploadedRequest;
 import com.triptyche.backend.domain.media.dto.MediaUploadedResponse;
 import com.triptyche.backend.domain.media.dto.TripMediaListResponse;
 import com.triptyche.backend.domain.media.dto.UnlocatedMediaResponse;
+import com.triptyche.backend.domain.media.dto.UploadStatusResponse;
 import com.triptyche.backend.domain.media.service.MediaCommandService;
 import com.triptyche.backend.domain.media.service.MediaQueryService;
 import com.triptyche.backend.domain.user.model.User;
@@ -118,5 +119,14 @@ public class MediaMetadataController {
           @PathVariable String tripKey,
           @Valid @RequestBody MediaUploadedRequest request) {
     return RestResponse.success(mediaCommandService.markUploadedAndEnqueue(user, tripKey, request));
+  }
+
+  @Tag(name = "3. 여행등록 페이지 API")
+  @Operation(summary = "업로드 상태 동기화", description = "페이지 진입/재진입 시 미처리 미디어 상태 일괄 조회. STOMP 손실 대비 안전망.")
+  @GetMapping("/upload-status")
+  public RestResponse<UploadStatusResponse> getUploadStatus(
+          @CurrentUser User user,
+          @PathVariable String tripKey) {
+    return RestResponse.success(mediaQueryService.getUploadStatus(user, tripKey));
   }
 }

--- a/src/main/java/com/triptyche/backend/domain/media/controller/MediaMetadataController.java
+++ b/src/main/java/com/triptyche/backend/domain/media/controller/MediaMetadataController.java
@@ -4,6 +4,8 @@ import com.triptyche.backend.domain.media.dto.MediaBatchDeleteRequest;
 import com.triptyche.backend.domain.media.dto.MediaBatchEditRequest;
 import com.triptyche.backend.domain.media.dto.MediaLocationEditRequest;
 import com.triptyche.backend.domain.media.dto.MediaUploadRequest;
+import com.triptyche.backend.domain.media.dto.MediaUploadedRequest;
+import com.triptyche.backend.domain.media.dto.MediaUploadedResponse;
 import com.triptyche.backend.domain.media.dto.TripMediaListResponse;
 import com.triptyche.backend.domain.media.dto.UnlocatedMediaResponse;
 import com.triptyche.backend.domain.media.service.MediaCommandService;
@@ -106,5 +108,15 @@ public class MediaMetadataController {
           @Valid @RequestBody MediaLocationEditRequest updateMediaFileLocation) {
     mediaCommandService.updateImageLocation(user, tripKey, mediaFileId, updateMediaFileLocation);
     return RestResponse.success("이미지 위치 정보가 업데이트 되었습니다.");
+  }
+
+  @Tag(name = "3. 여행등록 페이지 API")
+  @Operation(summary = "이미지 업로드 완료 통보 — v2", description = "FE가 S3 PUT 완료 후 호출. UPLOADED 전이 + 워커 enqueue.")
+  @PostMapping("/images-uploaded")
+  public RestResponse<MediaUploadedResponse> markImagesUploaded(
+          @CurrentUser User user,
+          @PathVariable String tripKey,
+          @Valid @RequestBody MediaUploadedRequest request) {
+    return RestResponse.success(mediaCommandService.markUploadedAndEnqueue(user, tripKey, request));
   }
 }

--- a/src/main/java/com/triptyche/backend/domain/media/dto/MediaUploadedRequest.java
+++ b/src/main/java/com/triptyche/backend/domain/media/dto/MediaUploadedRequest.java
@@ -1,0 +1,12 @@
+package com.triptyche.backend.domain.media.dto;
+
+import java.util.List;
+
+public record MediaUploadedRequest(List<Item> items) {
+  public record Item(
+      Long mediaFileId,
+      String recordDate,
+      Double latitude,
+      Double longitude
+  ) {}
+}

--- a/src/main/java/com/triptyche/backend/domain/media/dto/MediaUploadedResponse.java
+++ b/src/main/java/com/triptyche/backend/domain/media/dto/MediaUploadedResponse.java
@@ -1,0 +1,12 @@
+package com.triptyche.backend.domain.media.dto;
+
+import java.util.List;
+
+public record MediaUploadedResponse(List<Item> items) {
+  public record Item(
+      Long mediaFileId,
+      String currentUrl,
+      String finalUrl,
+      String status
+  ) {}
+}

--- a/src/main/java/com/triptyche/backend/domain/media/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/triptyche/backend/domain/media/dto/PresignedUrlResponse.java
@@ -7,7 +7,10 @@ public record PresignedUrlResponse(
 ) {
 
   public record PresignedUrl(
+      Long mediaFileId,
       String fileKey,
+      String tempKey,
+      String finalKey,
       String presignedPutUrl
   ) {
 

--- a/src/main/java/com/triptyche/backend/domain/media/dto/UploadStatusResponse.java
+++ b/src/main/java/com/triptyche/backend/domain/media/dto/UploadStatusResponse.java
@@ -2,7 +2,27 @@ package com.triptyche.backend.domain.media.dto;
 
 import java.util.List;
 
+/**
+ * GET /v1/trips/{tripKey}/media-files/upload-status 응답.
+ * STOMP 손실에 대비해 페이지 진입/재진입 시 미디어 상태를 일괄 동기화한다.
+ */
 public record UploadStatusResponse(List<Item> items) {
+
+  /**
+   * v2 흐름 외(기존 originals/ 경로로 등록된 row)에서 응답에 사용되는 status 값.
+   * ProcessingStatus enum에는 포함시키지 않음 — 상태 전이 대상이 아니라 표현용.
+   */
+  public static final String LEGACY_STATUS = "LEGACY";
+
+  /**
+   * @param mediaFileId   미디어 ID
+   * @param currentUrl    사용자에게 즉시 표시 가능한 URL — v2: tempKey 또는 finalKey URL, LEGACY: mediaLink
+   * @param finalUrl      최종 변환본 URL — v2: finalKey URL, LEGACY: mediaLink
+   * @param status        ProcessingStatus.name() (UPLOADED/PROCESSING/PROCESSED/FAILED)
+   *                      또는 {@value #LEGACY_STATUS} — v1으로 등록된 기존 row를 의미
+   * @param processedAt   PROCESSED 시각 (ISO-8601) 또는 null
+   * @param failureReason FAILED 인 경우만 채워짐, 그 외 null
+   */
   public record Item(
       Long mediaFileId,
       String currentUrl,

--- a/src/main/java/com/triptyche/backend/domain/media/dto/UploadStatusResponse.java
+++ b/src/main/java/com/triptyche/backend/domain/media/dto/UploadStatusResponse.java
@@ -1,0 +1,14 @@
+package com.triptyche.backend.domain.media.dto;
+
+import java.util.List;
+
+public record UploadStatusResponse(List<Item> items) {
+  public record Item(
+      Long mediaFileId,
+      String currentUrl,
+      String finalUrl,
+      String status,
+      String processedAt,
+      String failureReason
+  ) {}
+}

--- a/src/main/java/com/triptyche/backend/domain/media/event/ImageProcessedEvent.java
+++ b/src/main/java/com/triptyche/backend/domain/media/event/ImageProcessedEvent.java
@@ -1,0 +1,16 @@
+package com.triptyche.backend.domain.media.event;
+
+import java.time.LocalDateTime;
+
+/**
+ * Python 워커가 .webp 변환을 완료하고 BE가 media-processed-stream을 통해 결과를 수신한 뒤,
+ * MediaFile 상태를 PROCESSED로 전이한 후 @TransactionalEventListener(AFTER_COMMIT)로 STOMP 발행을 트리거하기 위한 이벤트.
+ *
+ * 페이로드는 primitive value만 — MediaFile 엔티티 참조 금지.
+ */
+public record ImageProcessedEvent(
+    Long mediaFileId,
+    Long userId,
+    String finalUrl,
+    LocalDateTime processedAt
+) {}

--- a/src/main/java/com/triptyche/backend/domain/media/event/ImageProcessedEventListener.java
+++ b/src/main/java/com/triptyche/backend/domain/media/event/ImageProcessedEventListener.java
@@ -1,0 +1,51 @@
+package com.triptyche.backend.domain.media.event;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ImageProcessedEventListener {
+
+  private final SimpMessagingTemplate messagingTemplate;
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onImageProcessed(ImageProcessedEvent event) {
+    try {
+      Map<String, Object> payload = Map.of(
+          "mediaFileId", event.mediaFileId(),
+          "finalUrl",    event.finalUrl(),
+          "status",      "PROCESSED",
+          "processedAt", event.processedAt().toString()
+      );
+      messagingTemplate.convertAndSend("/topic/media-processed/" + event.userId(), payload);
+      log.info("[MEDIA_PROCESSED] mediaFileId={} userId={}", event.mediaFileId(), event.userId());
+    } catch (Exception e) {
+      log.error("[MEDIA_PROCESSED] 전송 실패: mediaFileId={} userId={}", event.mediaFileId(), event.userId(), e);
+    }
+  }
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onImageProcessingFailed(ImageProcessingFailedEvent event) {
+    try {
+      Map<String, Object> payload = Map.of(
+          "mediaFileId", event.mediaFileId(),
+          "status",      "FAILED",
+          "reason",      event.reason()
+      );
+      messagingTemplate.convertAndSend("/topic/media-processed/" + event.userId(), payload);
+      log.info("[MEDIA_PROCESSING_FAILED] mediaFileId={} reason={}", event.mediaFileId(), event.reason());
+    } catch (Exception e) {
+      log.error("[MEDIA_PROCESSING_FAILED] 전송 실패: mediaFileId={} userId={}", event.mediaFileId(), event.userId(), e);
+    }
+  }
+}

--- a/src/main/java/com/triptyche/backend/domain/media/event/ImageProcessingFailedEvent.java
+++ b/src/main/java/com/triptyche/backend/domain/media/event/ImageProcessingFailedEvent.java
@@ -1,0 +1,11 @@
+package com.triptyche.backend.domain.media.event;
+
+/**
+ * Python 워커가 N회 재시도 끝에 처리에 실패했을 때 BE가 상태를 FAILED로 전이한 뒤
+ * @TransactionalEventListener(AFTER_COMMIT)로 STOMP "FAILED" payload를 발행하기 위한 이벤트.
+ */
+public record ImageProcessingFailedEvent(
+    Long mediaFileId,
+    Long userId,
+    String reason
+) {}

--- a/src/main/java/com/triptyche/backend/domain/media/event/MediaFileRegisteredEvent.java
+++ b/src/main/java/com/triptyche/backend/domain/media/event/MediaFileRegisteredEvent.java
@@ -1,5 +1,7 @@
 package com.triptyche.backend.domain.media.event;
 
+import java.util.Objects;
+
 public record MediaFileRegisteredEvent(
         Long mediaFileId,
         String originalKey,
@@ -8,10 +10,15 @@ public record MediaFileRegisteredEvent(
         String flow
 ) {
   public static MediaFileRegisteredEvent v1(Long mediaFileId, String originalKey) {
+    Objects.requireNonNull(mediaFileId, "mediaFileId");
+    Objects.requireNonNull(originalKey, "originalKey");
     return new MediaFileRegisteredEvent(mediaFileId, originalKey, null, null, "v1");
   }
 
   public static MediaFileRegisteredEvent v2(Long mediaFileId, String tempKey, String finalKey) {
+    Objects.requireNonNull(mediaFileId, "mediaFileId");
+    Objects.requireNonNull(tempKey, "tempKey");
+    Objects.requireNonNull(finalKey, "finalKey");
     return new MediaFileRegisteredEvent(mediaFileId, null, tempKey, finalKey, "v2");
   }
 }

--- a/src/main/java/com/triptyche/backend/domain/media/event/MediaFileRegisteredEvent.java
+++ b/src/main/java/com/triptyche/backend/domain/media/event/MediaFileRegisteredEvent.java
@@ -2,5 +2,16 @@ package com.triptyche.backend.domain.media.event;
 
 public record MediaFileRegisteredEvent(
         Long mediaFileId,
-        String originalKey
-) {}
+        String originalKey,
+        String tempKey,
+        String finalKey,
+        String flow
+) {
+  public static MediaFileRegisteredEvent v1(Long mediaFileId, String originalKey) {
+    return new MediaFileRegisteredEvent(mediaFileId, originalKey, null, null, "v1");
+  }
+
+  public static MediaFileRegisteredEvent v2(Long mediaFileId, String tempKey, String finalKey) {
+    return new MediaFileRegisteredEvent(mediaFileId, null, tempKey, finalKey, "v2");
+  }
+}

--- a/src/main/java/com/triptyche/backend/domain/media/model/MediaFile.java
+++ b/src/main/java/com/triptyche/backend/domain/media/model/MediaFile.java
@@ -124,4 +124,8 @@ public class MediaFile {
     this.processingStatus = ProcessingStatus.FAILED;
     this.failureReason = reason;
   }
+
+  public void updateMediaLink(String mediaLink) {
+    this.mediaLink = mediaLink;
+  }
 }

--- a/src/main/java/com/triptyche/backend/domain/media/model/MediaFile.java
+++ b/src/main/java/com/triptyche/backend/domain/media/model/MediaFile.java
@@ -2,8 +2,12 @@ package com.triptyche.backend.domain.media.model;
 
 import com.triptyche.backend.domain.trip.model.PinPoint;
 import com.triptyche.backend.domain.trip.model.Trip;
+import com.triptyche.backend.global.common.ResultCode;
+import com.triptyche.backend.global.exception.CustomException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -64,6 +68,22 @@ public class MediaFile {
   @Column(nullable = false, length = 255)
   private String mediaKey;
 
+  @Column(length = 255)
+  private String tempKey;
+
+  @Column(length = 255)
+  private String finalKey;
+
+  @Enumerated(EnumType.STRING)
+  @Column(length = 20)
+  private ProcessingStatus processingStatus;
+
+  @Temporal(TemporalType.TIMESTAMP)
+  private LocalDateTime processedAt;
+
+  @Column(length = 500)
+  private String failureReason;
+
   public void updateLocation(Double latitude, Double longitude, PinPoint pinPoint) {
     this.latitude = latitude;
     this.longitude = longitude;
@@ -72,5 +92,36 @@ public class MediaFile {
 
   public void updateRecordDate(LocalDateTime recordDate) {
     this.recordDate = recordDate;
+  }
+
+  public void markUploaded() {
+    if (processingStatus != null) {
+      throw new CustomException(ResultCode.INVALID_MEDIA_STATE);
+    }
+    this.processingStatus = ProcessingStatus.UPLOADED;
+  }
+
+  public void markProcessing() {
+    if (processingStatus != ProcessingStatus.UPLOADED) {
+      throw new CustomException(ResultCode.INVALID_MEDIA_STATE);
+    }
+    this.processingStatus = ProcessingStatus.PROCESSING;
+  }
+
+  public void markProcessed(LocalDateTime processedAt) {
+    if (processingStatus != ProcessingStatus.UPLOADED && processingStatus != ProcessingStatus.PROCESSING) {
+      throw new CustomException(ResultCode.INVALID_MEDIA_STATE);
+    }
+    this.processingStatus = ProcessingStatus.PROCESSED;
+    this.processedAt = processedAt;
+    this.failureReason = null;
+  }
+
+  public void markFailed(String reason) {
+    if (processingStatus == ProcessingStatus.PROCESSED) {
+      throw new CustomException(ResultCode.INVALID_MEDIA_STATE);
+    }
+    this.processingStatus = ProcessingStatus.FAILED;
+    this.failureReason = reason;
   }
 }

--- a/src/main/java/com/triptyche/backend/domain/media/model/MediaFile.java
+++ b/src/main/java/com/triptyche/backend/domain/media/model/MediaFile.java
@@ -24,6 +24,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 @Getter
 @Entity
@@ -49,7 +50,7 @@ public class MediaFile {
   private Trip trip;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "pin_point_id", nullable = false)
+  @JoinColumn(name = "pin_point_id")
   private PinPoint pinPoint;
 
   @Column(length = 50)
@@ -83,6 +84,10 @@ public class MediaFile {
 
   @Column(length = 500)
   private String failureReason;
+
+  @CreationTimestamp
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
 
   public void updateLocation(Double latitude, Double longitude, PinPoint pinPoint) {
     this.latitude = latitude;

--- a/src/main/java/com/triptyche/backend/domain/media/model/ProcessingStatus.java
+++ b/src/main/java/com/triptyche/backend/domain/media/model/ProcessingStatus.java
@@ -1,0 +1,8 @@
+package com.triptyche.backend.domain.media.model;
+
+public enum ProcessingStatus {
+  UPLOADED,
+  PROCESSING,
+  PROCESSED,
+  FAILED
+}

--- a/src/main/java/com/triptyche/backend/domain/media/repository/MediaFileRepository.java
+++ b/src/main/java/com/triptyche/backend/domain/media/repository/MediaFileRepository.java
@@ -75,6 +75,13 @@ public interface MediaFileRepository extends JpaRepository<MediaFile, Long> {
 
   List<MediaFile> findByTripTripId(Long tripId);
 
+  @Query("""
+          SELECT m FROM MediaFile m
+          LEFT JOIN FETCH m.pinPoint
+          WHERE m.trip.tripId = :tripId
+          """)
+  List<MediaFile> findByTripTripIdWithPinPoint(@Param("tripId") Long tripId);
+
   /**
    * 주어진 mediaKey 후보들 중 이미 해당 trip에 등록된 키만 반환.
    * 사용자가 같은 tripKey로 metadata POST를 반복했을 때 중복 INSERT를 막기 위한 사전 dedup 용도.

--- a/src/main/java/com/triptyche/backend/domain/media/repository/MediaFileRepository.java
+++ b/src/main/java/com/triptyche/backend/domain/media/repository/MediaFileRepository.java
@@ -115,4 +115,11 @@ public interface MediaFileRepository extends JpaRepository<MediaFile, Long> {
   @Modifying(clearAutomatically = true)
   @Query("DELETE FROM MediaFile m WHERE m.trip IN :trips")
   void deleteAllByTripIn(@Param("trips") List<Trip> trips);
+
+  @Query("""
+          SELECT m FROM MediaFile m
+          WHERE m.processingStatus IS NULL
+            AND m.createdAt < :threshold
+          """)
+  List<MediaFile> findOrphans(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/com/triptyche/backend/domain/media/scheduler/MediaOrphanCleanupExecutor.java
+++ b/src/main/java/com/triptyche/backend/domain/media/scheduler/MediaOrphanCleanupExecutor.java
@@ -1,0 +1,43 @@
+package com.triptyche.backend.domain.media.scheduler;
+
+import com.triptyche.backend.domain.media.event.MediaFilesS3DeleteRequestedEvent;
+import com.triptyche.backend.domain.media.model.MediaFile;
+import com.triptyche.backend.domain.media.repository.MediaFileRepository;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class MediaOrphanCleanupExecutor {
+
+  private static final Duration ORPHAN_THRESHOLD = Duration.ofHours(6);
+
+  private final MediaFileRepository mediaFileRepository;
+  private final ApplicationEventPublisher eventPublisher;
+
+  @Transactional
+  public int cleanup() {
+    LocalDateTime threshold = LocalDateTime.now().minus(ORPHAN_THRESHOLD);
+    List<MediaFile> orphans = mediaFileRepository.findOrphans(threshold);
+    if (orphans.isEmpty()) return 0;
+
+    List<String> tempKeys = orphans.stream()
+        .map(MediaFile::getTempKey)
+        .filter(Objects::nonNull)
+        .toList();
+
+    mediaFileRepository.deleteAll(orphans);
+
+    if (!tempKeys.isEmpty()) {
+      eventPublisher.publishEvent(new MediaFilesS3DeleteRequestedEvent(tempKeys));
+    }
+
+    return orphans.size();
+  }
+}

--- a/src/main/java/com/triptyche/backend/domain/media/scheduler/MediaOrphanCleanupScheduler.java
+++ b/src/main/java/com/triptyche/backend/domain/media/scheduler/MediaOrphanCleanupScheduler.java
@@ -1,0 +1,26 @@
+package com.triptyche.backend.domain.media.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MediaOrphanCleanupScheduler {
+
+  private final MediaOrphanCleanupExecutor executor;
+
+  @Scheduled(cron = "${triptyche.media.orphan-cleanup.cron:0 0 */6 * * *}")
+  public void run() {
+    try {
+      int deleted = executor.cleanup();
+      if (deleted > 0) {
+        log.info("[MEDIA_ORPHAN_CLEANUP] 삭제 완료 — count={}", deleted);
+      }
+    } catch (Exception e) {
+      log.error("[MEDIA_ORPHAN_CLEANUP] 실패", e);
+    }
+  }
+}

--- a/src/main/java/com/triptyche/backend/domain/media/service/MediaCommandService.java
+++ b/src/main/java/com/triptyche/backend/domain/media/service/MediaCommandService.java
@@ -4,6 +4,8 @@ import com.triptyche.backend.domain.media.dto.MediaBatchDeleteRequest;
 import com.triptyche.backend.domain.media.dto.MediaBatchEditRequest;
 import com.triptyche.backend.domain.media.dto.MediaLocationEditRequest;
 import com.triptyche.backend.domain.media.dto.MediaUploadRequest;
+import com.triptyche.backend.domain.media.dto.MediaUploadedRequest;
+import com.triptyche.backend.domain.media.dto.MediaUploadedResponse;
 import com.triptyche.backend.domain.media.event.MediaFileAddedEvent;
 import com.triptyche.backend.domain.media.event.MediaFileDeletedEvent;
 import com.triptyche.backend.domain.media.event.MediaFileLocationUpdatedEvent;
@@ -98,10 +100,8 @@ public class MediaCommandService {
     List<MediaFile> savedMediaFiles = mediaFileRepository.saveAll(mediaFiles);
 
     savedMediaFiles.forEach(mediaFile ->
-            eventPublisher.publishEvent(new MediaFileRegisteredEvent(
-                    mediaFile.getMediaFileId(),
-                    mediaFile.getMediaKey()
-            ))
+            eventPublisher.publishEvent(
+                    MediaFileRegisteredEvent.v1(mediaFile.getMediaFileId(), mediaFile.getMediaKey()))
     );
 
     // Redis 처리 (위치 0.0인 파일들만) — DB 커밋 완료 후 이벤트로 처리
@@ -237,6 +237,53 @@ public class MediaCommandService {
             actorId,
             actorNickname,
             isOwner));
+  }
+
+  @Transactional
+  public MediaUploadedResponse markUploadedAndEnqueue(User user, String tripKey, MediaUploadedRequest request) {
+    Trip trip = tripAccessGuard.validateAccessibleTripByKey(tripKey, user);
+
+    List<Long> ids = request.items().stream().map(MediaUploadedRequest.Item::mediaFileId).toList();
+    Map<Long, MediaFile> byId = mediaFileRepository.findAllById(ids).stream()
+            .collect(Collectors.toMap(MediaFile::getMediaFileId, mf -> mf));
+
+    if (byId.size() != ids.size()) {
+      throw new CustomException(ResultCode.MEDIA_FILE_NOT_FOUND);
+    }
+
+    byId.values().forEach(mf -> {
+      if (!mf.getTrip().getTripId().equals(trip.getTripId())) {
+        throw new CustomException(ResultCode.ACCESS_DENIED);
+      }
+    });
+
+    List<PinPoint> existingPinPoints = pinPointService.findAllByTripId(trip.getTripId());
+
+    List<MediaUploadedResponse.Item> items = request.items().stream()
+            .map(reqItem -> {
+              MediaFile mf = byId.get(reqItem.mediaFileId());
+
+              LocalDateTime recordDate = DateFormatter.convertToLocalDateTime(reqItem.recordDate());
+              PinPoint pinPoint = pinPointService.assignPinPoint(
+                      existingPinPoints, trip, reqItem.latitude(), reqItem.longitude());
+              mf.updateRecordDate(recordDate);
+              mf.updateLocation(reqItem.latitude(), reqItem.longitude(), pinPoint);
+
+              String currentUrl = s3KeyResolver.buildUrl(mf.getTempKey());
+              mf.updateMediaLink(currentUrl);
+
+              mf.markUploaded();
+
+              eventPublisher.publishEvent(
+                      MediaFileRegisteredEvent.v2(mf.getMediaFileId(), mf.getTempKey(), mf.getFinalKey()));
+
+              String finalUrl = s3KeyResolver.buildUrl(mf.getFinalKey());
+              return new MediaUploadedResponse.Item(
+                      mf.getMediaFileId(), currentUrl, finalUrl, mf.getProcessingStatus().name());
+            })
+            .toList();
+
+    return new MediaUploadedResponse(items);
   }
 
 }

--- a/src/main/java/com/triptyche/backend/domain/media/service/MediaPresignService.java
+++ b/src/main/java/com/triptyche/backend/domain/media/service/MediaPresignService.java
@@ -3,14 +3,19 @@ package com.triptyche.backend.domain.media.service;
 import com.triptyche.backend.domain.media.dto.PresignedUrlCreateRequest;
 import com.triptyche.backend.domain.media.dto.PresignedUrlResponse;
 import com.triptyche.backend.domain.media.dto.PresignedUrlResponse.PresignedUrl;
+import com.triptyche.backend.domain.media.model.MediaFile;
+import com.triptyche.backend.domain.media.repository.MediaFileRepository;
+import com.triptyche.backend.domain.trip.model.Trip;
+import com.triptyche.backend.domain.trip.service.TripAccessGuard;
 import com.triptyche.backend.domain.user.model.User;
 import com.triptyche.backend.global.s3.PresignedURLService;
 import com.triptyche.backend.global.s3.S3KeyResolver;
-import com.triptyche.backend.domain.trip.service.TripAccessGuard;
 import java.time.Duration;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,18 +25,40 @@ public class MediaPresignService {
 
     private final TripAccessGuard tripAccessGuard;
     private final PresignedURLService presignedURLService;
+    private final MediaFileRepository mediaFileRepository;
 
+    @Transactional
     public PresignedUrlResponse issuePutUrls(User user, String tripKey, PresignedUrlCreateRequest request) {
-        tripAccessGuard.validateAccessibleTripByKey(tripKey, user);
+        Trip trip = tripAccessGuard.validateAccessibleTripByKey(tripKey, user);
 
         List<PresignedUrl> presignedUrls = request.files().stream()
                 .map(file -> {
-                    String fileKey = S3KeyResolver.buildOriginalKey(tripKey, file.fileName());
-                    String putUrl = presignedURLService.generatePresignedPutUrl(fileKey, PRESIGNED_URL_TTL);
-                    return new PresignedUrl(fileKey, putUrl);
+                    String uuid = UUID.randomUUID().toString();
+                    String extension = extractExtension(file.fileName());
+                    String tempKey = S3KeyResolver.buildTempKey(trip.getTripId(), uuid, extension);
+                    String finalKey = S3KeyResolver.buildFinalKey(trip.getTripId(), uuid);
+
+                    MediaFile mf = MediaFile.builder()
+                            .trip(trip)
+                            .mediaType("image/webp")
+                            .mediaKey(finalKey)
+                            .tempKey(tempKey)
+                            .finalKey(finalKey)
+                            .build();
+                    MediaFile saved = mediaFileRepository.save(mf);
+
+                    String presignedPutUrl = presignedURLService.generatePresignedPutUrl(tempKey, PRESIGNED_URL_TTL);
+                    return new PresignedUrl(saved.getMediaFileId(), tempKey, tempKey, finalKey, presignedPutUrl);
                 })
                 .toList();
 
         return new PresignedUrlResponse(presignedUrls);
+    }
+
+    private static String extractExtension(String fileName) {
+        if (fileName == null) return "jpg";
+        int dot = fileName.lastIndexOf('.');
+        if (dot < 0 || dot == fileName.length() - 1) return "jpg";
+        return fileName.substring(dot + 1).toLowerCase();
     }
 }

--- a/src/main/java/com/triptyche/backend/domain/media/service/MediaProcessingService.java
+++ b/src/main/java/com/triptyche/backend/domain/media/service/MediaProcessingService.java
@@ -1,0 +1,53 @@
+package com.triptyche.backend.domain.media.service;
+
+import com.triptyche.backend.domain.media.event.ImageProcessedEvent;
+import com.triptyche.backend.domain.media.event.ImageProcessingFailedEvent;
+import com.triptyche.backend.domain.media.model.MediaFile;
+import com.triptyche.backend.domain.media.model.ProcessingStatus;
+import com.triptyche.backend.domain.media.repository.MediaFileRepository;
+import com.triptyche.backend.global.common.ResultCode;
+import com.triptyche.backend.global.exception.CustomException;
+import com.triptyche.backend.global.s3.S3KeyResolver;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MediaProcessingService {
+
+  private final MediaFileRepository mediaFileRepository;
+  private final S3KeyResolver s3KeyResolver;
+  private final ApplicationEventPublisher eventPublisher;
+
+  @Transactional
+  public void applyProcessedResult(Long mediaFileId, String finalKey, LocalDateTime processedAt) {
+    MediaFile mf = mediaFileRepository.findById(mediaFileId)
+        .orElseThrow(() -> new CustomException(ResultCode.MEDIA_FILE_NOT_FOUND));
+
+    if (mf.getProcessingStatus() == ProcessingStatus.PROCESSED) return;
+
+    mf.markProcessed(processedAt);
+
+    String finalUrl = s3KeyResolver.buildUrl(finalKey);
+    mf.updateMediaLink(finalUrl);
+
+    Long userId = mf.getTrip().getUser().getUserId();
+    eventPublisher.publishEvent(new ImageProcessedEvent(mediaFileId, userId, finalUrl, processedAt));
+  }
+
+  @Transactional
+  public void applyFailedResult(Long mediaFileId, String reason) {
+    MediaFile mf = mediaFileRepository.findById(mediaFileId)
+        .orElseThrow(() -> new CustomException(ResultCode.MEDIA_FILE_NOT_FOUND));
+
+    if (mf.getProcessingStatus() == ProcessingStatus.PROCESSED) return;
+
+    mf.markFailed(reason);
+
+    Long userId = mf.getTrip().getUser().getUserId();
+    eventPublisher.publishEvent(new ImageProcessingFailedEvent(mediaFileId, userId, reason));
+  }
+}

--- a/src/main/java/com/triptyche/backend/domain/media/service/MediaQueryService.java
+++ b/src/main/java/com/triptyche/backend/domain/media/service/MediaQueryService.java
@@ -109,7 +109,7 @@ public class MediaQueryService {
             mf.getMediaFileId(),
             mf.getTempKey() != null ? s3KeyResolver.buildUrl(mf.getTempKey()) : mf.getMediaLink(),
             mf.getFinalKey() != null ? s3KeyResolver.buildUrl(mf.getFinalKey()) : mf.getMediaLink(),
-            mf.getProcessingStatus() != null ? mf.getProcessingStatus().name() : "LEGACY",
+            mf.getProcessingStatus() != null ? mf.getProcessingStatus().name() : UploadStatusResponse.LEGACY_STATUS,
             mf.getProcessedAt() != null ? mf.getProcessedAt().toString() : null,
             mf.getProcessingStatus() == ProcessingStatus.FAILED ? mf.getFailureReason() : null
         ))

--- a/src/main/java/com/triptyche/backend/domain/media/service/MediaQueryService.java
+++ b/src/main/java/com/triptyche/backend/domain/media/service/MediaQueryService.java
@@ -9,13 +9,16 @@ import com.triptyche.backend.domain.media.dto.MediaFileResponse;
 import com.triptyche.backend.domain.media.dto.TripMediaListResponse;
 import com.triptyche.backend.domain.media.dto.UnlocatedMediaResponse;
 import com.triptyche.backend.domain.media.dto.UnlocatedMediaResponse.MediaSummary;
+import com.triptyche.backend.domain.media.dto.UploadStatusResponse;
 import com.triptyche.backend.domain.media.model.MediaFile;
+import com.triptyche.backend.domain.media.model.ProcessingStatus;
 import com.triptyche.backend.domain.media.repository.MediaFileRepository;
 import com.triptyche.backend.domain.trip.model.Trip;
 import com.triptyche.backend.domain.trip.service.TripAccessGuard;
 import com.triptyche.backend.domain.user.model.User;
 import com.triptyche.backend.global.common.ResultCode;
 import com.triptyche.backend.global.exception.CustomException;
+import com.triptyche.backend.global.s3.S3KeyResolver;
 import com.triptyche.backend.global.util.DateFormatter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -36,6 +39,7 @@ public class MediaQueryService {
   private final MediaFileRepository mediaFileRepository;
   private final TripAccessGuard tripAccessGuard;
   private final UnlocatedMediaCacheService unlocatedMediaCacheService;
+  private final S3KeyResolver s3KeyResolver;
 
   @Transactional(readOnly = true)
   public TripMediaListResponse getTripImages(User user, String tripKey) {
@@ -93,5 +97,24 @@ public class MediaQueryService {
   @Transactional(readOnly = true)
   public List<MediaFileSummary> findSummariesByTripAndDate(Long tripId, LocalDateTime start, LocalDateTime end) {
     return mediaFileRepository.findByTripTripIdAndRecordDate(tripId, start, end, DEFAULT_INVALID_DATE);
+  }
+
+  @Transactional(readOnly = true)
+  public UploadStatusResponse getUploadStatus(User user, String tripKey) {
+    Trip trip = tripAccessGuard.validateAccessibleTripByKey(tripKey, user);
+    List<MediaFile> rows = mediaFileRepository.findByTripTripIdWithPinPoint(trip.getTripId());
+
+    List<UploadStatusResponse.Item> items = rows.stream()
+        .map(mf -> new UploadStatusResponse.Item(
+            mf.getMediaFileId(),
+            mf.getTempKey() != null ? s3KeyResolver.buildUrl(mf.getTempKey()) : mf.getMediaLink(),
+            mf.getFinalKey() != null ? s3KeyResolver.buildUrl(mf.getFinalKey()) : mf.getMediaLink(),
+            mf.getProcessingStatus() != null ? mf.getProcessingStatus().name() : "LEGACY",
+            mf.getProcessedAt() != null ? mf.getProcessedAt().toString() : null,
+            mf.getProcessingStatus() == ProcessingStatus.FAILED ? mf.getFailureReason() : null
+        ))
+        .toList();
+
+    return new UploadStatusResponse(items);
   }
 }

--- a/src/main/java/com/triptyche/backend/global/common/ResultCode.java
+++ b/src/main/java/com/triptyche/backend/global/common/ResultCode.java
@@ -49,6 +49,7 @@ public enum ResultCode {
   INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, 4005, "잘못된 날짜 형식입니다. yyyy-MM-dd 형식으로 입력해주세요."),
   INVALID_COORDINATE(HttpStatus.BAD_REQUEST, 4006, "잘못된 좌표 형식입니다."),
   INVALID_TRIP_STATE(HttpStatus.BAD_REQUEST, 4007, "유효하지 않은 여행 상태입니다."),
+  INVALID_MEDIA_STATE(HttpStatus.BAD_REQUEST, 4008, "유효하지 않은 미디어 상태입니다."),
 
   // 파일 업로드 및 처리 관련 오류 코드 (5000번대)
   S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "S3 업로드에 실패했습니다."),

--- a/src/main/java/com/triptyche/backend/global/config/RedisConfig.java
+++ b/src/main/java/com/triptyche/backend/global/config/RedisConfig.java
@@ -1,8 +1,11 @@
 package com.triptyche.backend.global.config;
 
+import com.triptyche.backend.global.redis.MediaProcessedStreamConsumer;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.SocketOptions;
+import java.net.InetAddress;
 import java.time.Duration;
+import java.util.Map;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.data.redis.RedisHealthIndicator;
@@ -13,8 +16,14 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 public class RedisConfig {
@@ -97,5 +106,59 @@ public class RedisConfig {
   @Bean
   public RedisHealthIndicator redisHealthIndicator(RedisConnectionFactory redisConnectionFactory) {
     return new RedisHealthIndicator(redisConnectionFactory);
+  }
+
+  @Bean
+  public StreamMessageListenerContainer<String, MapRecord<String, String, String>> mediaProcessedStreamContainer(
+      RedisConnectionFactory connectionFactory,
+      MediaProcessedStreamConsumer consumer
+  ) {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(2);
+    executor.setMaxPoolSize(4);
+    executor.setQueueCapacity(16);
+    executor.setThreadNamePrefix("media-processed-");
+    executor.initialize();
+
+    StreamMessageListenerContainer.StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options =
+        StreamMessageListenerContainer.StreamMessageListenerContainerOptions.builder()
+            .pollTimeout(Duration.ofSeconds(2))
+            .serializer(new StringRedisSerializer())
+            .executor(executor)
+            .build();
+
+    StreamMessageListenerContainer<String, MapRecord<String, String, String>> container =
+        StreamMessageListenerContainer.create(connectionFactory, options);
+
+    // 스트림 + 컨슈머 그룹 생성 (이미 존재하면 무시)
+    try {
+      redisTemplate().opsForStream().createGroup("media-processed-stream", "media-processed-workers");
+    } catch (Exception busyGroup) {
+      // BUSYGROUP: 이미 존재 — 무시
+      // NOGROUP / stream 없음 에러면 XADD로 stream을 먼저 생성 후 재시도
+      try {
+        redisTemplate().opsForStream().add(
+            MapRecord.create("media-processed-stream", Map.of("init", "true")));
+        redisTemplate().opsForStream().createGroup("media-processed-stream", "media-processed-workers");
+      } catch (Exception e) {
+        // 재시도 실패 시에도 컨테이너는 기동 — 스트림이 추후 생성되면 자동 구독
+      }
+    }
+
+    String consumerName;
+    try {
+      consumerName = InetAddress.getLocalHost().getHostName();
+    } catch (Exception e) {
+      consumerName = "be-1";
+    }
+
+    container.receive(
+        Consumer.from("media-processed-workers", consumerName),
+        StreamOffset.create("media-processed-stream", ReadOffset.lastConsumed()),
+        consumer
+    );
+
+    container.start();
+    return container;
   }
 }

--- a/src/main/java/com/triptyche/backend/global/config/WebSocketConfig.java
+++ b/src/main/java/com/triptyche/backend/global/config/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.triptyche.backend.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.triptyche.backend.global.websocket.StompTopicAuthInterceptor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -8,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.converter.DefaultContentTypeResolver;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -23,6 +25,7 @@ import org.springframework.web.socket.config.annotation.WebSocketTransportRegist
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   private final ObjectMapper objectMapper;
+  private final StompTopicAuthInterceptor stompTopicAuthInterceptor;
 
   @Override
   public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -56,6 +59,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     registration.setSendTimeLimit(15 * 1000)        // 메시지 전송 시간 제한 (15초)
                 .setSendBufferSizeLimit(512 * 1024) // 전송 버퍼 크기 제한 (512KB)
                 .setMessageSizeLimit(64 * 1024);    // 단일 메시지 크기 제한 (64KB)
+  }
+
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+    registration.interceptors(stompTopicAuthInterceptor);
   }
 
   @Override

--- a/src/main/java/com/triptyche/backend/global/redis/ImageProcessingPublisher.java
+++ b/src/main/java/com/triptyche/backend/global/redis/ImageProcessingPublisher.java
@@ -24,12 +24,21 @@ public class ImageProcessingPublisher {
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void publish(MediaFileRegisteredEvent event) {
     try {
-      redisTemplate.opsForStream().add(
-              MapRecord.create(STREAM_KEY, Map.of(
-                      "mediaFileId", String.valueOf(event.mediaFileId()),
-                      "originalKey", event.originalKey()
-              ))
-      );
+      Map<String, String> payload;
+      if ("v2".equals(event.flow())) {
+        payload = Map.of(
+                "mediaFileId", String.valueOf(event.mediaFileId()),
+                "tempKey", event.tempKey(),
+                "finalKey", event.finalKey(),
+                "flow", "v2"
+        );
+      } else {
+        payload = Map.of(
+                "mediaFileId", String.valueOf(event.mediaFileId()),
+                "originalKey", event.originalKey()
+        );
+      }
+      redisTemplate.opsForStream().add(MapRecord.create(STREAM_KEY, payload));
     } catch (Exception e) {
       log.error("Redis Stream XADD 실패 - mediaFileId: {}", event.mediaFileId(), e);
     }

--- a/src/main/java/com/triptyche/backend/global/redis/MediaProcessedStreamConsumer.java
+++ b/src/main/java/com/triptyche/backend/global/redis/MediaProcessedStreamConsumer.java
@@ -1,0 +1,43 @@
+package com.triptyche.backend.global.redis;
+
+import com.triptyche.backend.domain.media.service.MediaProcessingService;
+import java.time.LocalDateTime;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.stream.StreamListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MediaProcessedStreamConsumer implements StreamListener<String, MapRecord<String, String, String>> {
+
+  private final MediaProcessingService mediaProcessingService;
+
+  @Override
+  public void onMessage(MapRecord<String, String, String> message) {
+    Map<String, String> fields = message.getValue();
+    Long mediaFileId;
+    try {
+      mediaFileId = Long.parseLong(fields.get("mediaFileId"));
+    } catch (Exception e) {
+      log.warn("[media-processed-stream] 잘못된 페이로드 — mediaFileId 파싱 실패: {}", fields, e);
+      return;
+    }
+
+    try {
+      if ("FAILED".equals(fields.get("status"))) {
+        String reason = fields.getOrDefault("reason", "unknown");
+        mediaProcessingService.applyFailedResult(mediaFileId, reason);
+      } else {
+        String finalKey = fields.get("finalKey");
+        LocalDateTime processedAt = LocalDateTime.parse(fields.get("processedAt"));
+        mediaProcessingService.applyProcessedResult(mediaFileId, finalKey, processedAt);
+      }
+    } catch (Exception e) {
+      log.warn("[media-processed-stream] 메시지 처리 실패 — mediaFileId: {}, fields: {}", mediaFileId, fields, e);
+    }
+  }
+}

--- a/src/main/java/com/triptyche/backend/global/s3/S3KeyResolver.java
+++ b/src/main/java/com/triptyche/backend/global/s3/S3KeyResolver.java
@@ -8,6 +8,8 @@ public class S3KeyResolver {
 
     public static final String ORIGINALS_PREFIX = "originals/";
     public static final String SEED_PREFIX = "seed/";
+    public static final String TEMP_PREFIX = "temp/";
+    public static final String PROCESSED_PREFIX = "processed/";
 
     private final String bucketName;
 
@@ -20,6 +22,39 @@ public class S3KeyResolver {
 
     public static String buildOriginalKey(String tripKey, String fileName) {
         return ORIGINALS_PREFIX + tripKey + "/" + fileName;
+    }
+
+    public static String buildTempKey(Long tripId, String uuid, String extension) {
+        String ext = extension == null || extension.isBlank() ? "jpg" : extension.replaceFirst("^\\.", "");
+        return TEMP_PREFIX + tripId + "/" + uuid + "." + ext;
+    }
+
+    public static String buildFinalKey(Long tripId, String uuid) {
+        return PROCESSED_PREFIX + tripId + "/" + uuid + ".webp";
+    }
+
+    public static boolean isTempKey(String key) {
+        return key != null && key.startsWith(TEMP_PREFIX);
+    }
+
+    public static boolean isFinalKey(String key) {
+        return key != null && key.startsWith(PROCESSED_PREFIX);
+    }
+
+    /**
+     * temp/{tripId}/{uuid}.{ext} → processed/{tripId}/{uuid}.webp
+     * 형식이 맞지 않으면 null 반환.
+     */
+    public static String swapTempToFinalKey(String tempKey) {
+        if (!isTempKey(tempKey)) return null;
+        String rest = tempKey.substring(TEMP_PREFIX.length());
+        int slash = rest.indexOf('/');
+        if (slash < 0) return null;
+        String tripPart = rest.substring(0, slash);
+        String filePart = rest.substring(slash + 1);
+        int dot = filePart.lastIndexOf('.');
+        String uuid = dot > 0 ? filePart.substring(0, dot) : filePart;
+        return PROCESSED_PREFIX + tripPart + "/" + uuid + ".webp";
     }
 
     public static boolean isOriginalKey(String key) {

--- a/src/main/java/com/triptyche/backend/global/websocket/StompTopicAuthInterceptor.java
+++ b/src/main/java/com/triptyche/backend/global/websocket/StompTopicAuthInterceptor.java
@@ -1,0 +1,62 @@
+package com.triptyche.backend.global.websocket;
+
+import com.triptyche.backend.domain.user.model.User;
+import com.triptyche.backend.domain.user.repository.UserRepository;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StompTopicAuthInterceptor implements ChannelInterceptor {
+
+  private static final String MEDIA_PROCESSED_PREFIX = "/topic/media-processed/";
+
+  private final UserRepository userRepository;
+
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+    if (accessor.getCommand() != StompCommand.SUBSCRIBE) {
+      return message;
+    }
+
+    String destination = accessor.getDestination();
+    if (destination == null || !destination.startsWith(MEDIA_PROCESSED_PREFIX)) {
+      return message;
+    }
+
+    String pathUserId = destination.substring(MEDIA_PROCESSED_PREFIX.length());
+    long requestedUserId;
+    try {
+      requestedUserId = Long.parseLong(pathUserId);
+    } catch (NumberFormatException e) {
+      log.warn("STOMP SUBSCRIBE 거부 — 유효하지 않은 userId 형식: destination={}", destination);
+      throw new MessageDeliveryException("invalid topic");
+    }
+
+    Principal principal = accessor.getUser();
+    if (principal == null) {
+      log.warn("STOMP SUBSCRIBE 거부 — 인증되지 않은 사용자: destination={}", destination);
+      throw new MessageDeliveryException("forbidden topic subscription");
+    }
+
+    String userEmail = principal.getName();
+    User user = userRepository.findByUserEmail(userEmail).orElse(null);
+    if (user == null || !user.getUserId().equals(requestedUserId)) {
+      log.warn("STOMP SUBSCRIBE 거부 — 권한 없음: email={}, requestedUserId={}", userEmail, requestedUserId);
+      throw new MessageDeliveryException("forbidden topic subscription");
+    }
+
+    return message;
+  }
+}

--- a/src/test/java/com/triptyche/backend/domain/media/event/ImageProcessedEventListenerTest.java
+++ b/src/test/java/com/triptyche/backend/domain/media/event/ImageProcessedEventListenerTest.java
@@ -1,0 +1,123 @@
+package com.triptyche.backend.domain.media.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@ExtendWith(MockitoExtension.class)
+class ImageProcessedEventListenerTest {
+
+  @Mock
+  private SimpMessagingTemplate messagingTemplate;
+
+  @InjectMocks
+  private ImageProcessedEventListener listener;
+
+  private static final Long MEDIA_FILE_ID = 1L;
+  private static final Long USER_ID = 42L;
+  private static final String FINAL_URL = "https://cdn.example.com/image.webp";
+  private static final LocalDateTime PROCESSED_AT = LocalDateTime.of(2024, 1, 15, 10, 30, 0);
+  private static final String REASON = "conversion failed";
+  private static final String EXPECTED_TOPIC = "/topic/media-processed/42";
+
+  @Nested
+  @DisplayName("onImageProcessed()")
+  class OnImageProcessed {
+
+    @Test
+    @DisplayName("PROCESSED payload를 올바른 토픽으로 전송한다")
+    void onImageProcessed_sendsCorrectPayloadToTopic() {
+      ImageProcessedEvent event = new ImageProcessedEvent(MEDIA_FILE_ID, USER_ID, FINAL_URL, PROCESSED_AT);
+
+      listener.onImageProcessed(event);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+      verify(messagingTemplate).convertAndSend(eq(EXPECTED_TOPIC), captor.capture());
+
+      Map<String, Object> payload = captor.getValue();
+      assertThat(payload).containsEntry("mediaFileId", MEDIA_FILE_ID);
+      assertThat(payload).containsEntry("finalUrl", FINAL_URL);
+      assertThat(payload).containsEntry("status", "PROCESSED");
+      assertThat(payload).containsEntry("processedAt", PROCESSED_AT.toString());
+    }
+
+    @Test
+    @DisplayName("messagingTemplate이 예외를 던져도 listener는 예외를 전파하지 않는다")
+    void onImageProcessed_whenSendThrows_doesNotPropagate() {
+      ImageProcessedEvent event = new ImageProcessedEvent(MEDIA_FILE_ID, USER_ID, FINAL_URL, PROCESSED_AT);
+      doThrow(new RuntimeException("STOMP error")).when(messagingTemplate)
+          .convertAndSend(eq(EXPECTED_TOPIC), any(Map.class));
+
+      assertThatCode(() -> listener.onImageProcessed(event)).doesNotThrowAnyException();
+    }
+  }
+
+  @Nested
+  @DisplayName("onImageProcessingFailed()")
+  class OnImageProcessingFailed {
+
+    @Test
+    @DisplayName("FAILED payload를 올바른 토픽으로 전송한다")
+    void onImageProcessingFailed_sendsCorrectPayloadToTopic() {
+      ImageProcessingFailedEvent event = new ImageProcessingFailedEvent(MEDIA_FILE_ID, USER_ID, REASON);
+
+      listener.onImageProcessingFailed(event);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+      verify(messagingTemplate).convertAndSend(eq(EXPECTED_TOPIC), captor.capture());
+
+      Map<String, Object> payload = captor.getValue();
+      assertThat(payload).containsEntry("mediaFileId", MEDIA_FILE_ID);
+      assertThat(payload).containsEntry("status", "FAILED");
+      assertThat(payload).containsEntry("reason", REASON);
+    }
+
+    @Test
+    @DisplayName("messagingTemplate이 예외를 던져도 listener는 예외를 전파하지 않는다")
+    void onImageProcessingFailed_whenSendThrows_doesNotPropagate() {
+      ImageProcessingFailedEvent event = new ImageProcessingFailedEvent(MEDIA_FILE_ID, USER_ID, REASON);
+      doThrow(new RuntimeException("STOMP error")).when(messagingTemplate)
+          .convertAndSend(eq(EXPECTED_TOPIC), any(Map.class));
+
+      assertThatCode(() -> listener.onImageProcessingFailed(event)).doesNotThrowAnyException();
+    }
+  }
+
+  @Nested
+  @DisplayName("@TransactionalEventListener 어노테이션 검증")
+  class AnnotationVerification {
+
+    @Test
+    @DisplayName("onImageProcessed에 @TransactionalEventListener가 선언되어 있다")
+    void onImageProcessed_hasTransactionalEventListenerAnnotation() throws NoSuchMethodException {
+      Method method = ImageProcessedEventListener.class.getMethod("onImageProcessed", ImageProcessedEvent.class);
+      assertThat(method.isAnnotationPresent(TransactionalEventListener.class)).isTrue();
+    }
+
+    @Test
+    @DisplayName("onImageProcessingFailed에 @TransactionalEventListener가 선언되어 있다")
+    void onImageProcessingFailed_hasTransactionalEventListenerAnnotation() throws NoSuchMethodException {
+      Method method = ImageProcessedEventListener.class.getMethod("onImageProcessingFailed", ImageProcessingFailedEvent.class);
+      assertThat(method.isAnnotationPresent(TransactionalEventListener.class)).isTrue();
+    }
+  }
+}

--- a/src/test/java/com/triptyche/backend/domain/media/event/MediaFileRegisteredEventTest.java
+++ b/src/test/java/com/triptyche/backend/domain/media/event/MediaFileRegisteredEventTest.java
@@ -1,0 +1,81 @@
+package com.triptyche.backend.domain.media.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MediaFileRegisteredEventTest {
+
+  @Nested
+  @DisplayName("v1()")
+  class V1Factory {
+
+    @Test
+    @DisplayName("mediaFileId/originalKey 채워서 v1 이벤트 생성")
+    void create() {
+      MediaFileRegisteredEvent event = MediaFileRegisteredEvent.v1(42L, "originals/a/b.jpg");
+
+      assertThat(event.mediaFileId()).isEqualTo(42L);
+      assertThat(event.originalKey()).isEqualTo("originals/a/b.jpg");
+      assertThat(event.tempKey()).isNull();
+      assertThat(event.finalKey()).isNull();
+      assertThat(event.flow()).isEqualTo("v1");
+    }
+
+    @Test
+    @DisplayName("mediaFileId null이면 NPE")
+    void fail_when_mediaFileId_null() {
+      assertThatNullPointerException()
+              .isThrownBy(() -> MediaFileRegisteredEvent.v1(null, "originals/x.jpg"));
+    }
+
+    @Test
+    @DisplayName("originalKey null이면 NPE")
+    void fail_when_originalKey_null() {
+      assertThatNullPointerException()
+              .isThrownBy(() -> MediaFileRegisteredEvent.v1(1L, null));
+    }
+  }
+
+  @Nested
+  @DisplayName("v2()")
+  class V2Factory {
+
+    @Test
+    @DisplayName("mediaFileId/tempKey/finalKey 채워서 v2 이벤트 생성")
+    void create() {
+      MediaFileRegisteredEvent event = MediaFileRegisteredEvent.v2(
+              42L, "temp/1/u.jpg", "processed/1/u.webp");
+
+      assertThat(event.mediaFileId()).isEqualTo(42L);
+      assertThat(event.originalKey()).isNull();
+      assertThat(event.tempKey()).isEqualTo("temp/1/u.jpg");
+      assertThat(event.finalKey()).isEqualTo("processed/1/u.webp");
+      assertThat(event.flow()).isEqualTo("v2");
+    }
+
+    @Test
+    @DisplayName("mediaFileId null이면 NPE")
+    void fail_when_mediaFileId_null() {
+      assertThatNullPointerException()
+              .isThrownBy(() -> MediaFileRegisteredEvent.v2(null, "temp/x.jpg", "processed/x.webp"));
+    }
+
+    @Test
+    @DisplayName("tempKey null이면 NPE — Python 워커가 분기 처리 불가")
+    void fail_when_tempKey_null() {
+      assertThatNullPointerException()
+              .isThrownBy(() -> MediaFileRegisteredEvent.v2(1L, null, "processed/x.webp"));
+    }
+
+    @Test
+    @DisplayName("finalKey null이면 NPE — BE 컨슈머가 URL 생성 불가")
+    void fail_when_finalKey_null() {
+      assertThatNullPointerException()
+              .isThrownBy(() -> MediaFileRegisteredEvent.v2(1L, "temp/x.jpg", null));
+    }
+  }
+}

--- a/src/test/java/com/triptyche/backend/domain/media/model/MediaFileTest.java
+++ b/src/test/java/com/triptyche/backend/domain/media/model/MediaFileTest.java
@@ -1,0 +1,163 @@
+package com.triptyche.backend.domain.media.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.triptyche.backend.global.common.ResultCode;
+import com.triptyche.backend.global.exception.CustomException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MediaFileTest {
+
+  private MediaFile mediaFile;
+
+  @BeforeEach
+  void setUp() {
+    mediaFile = MediaFile.builder()
+        .mediaKey("test-key")
+        .build();
+  }
+
+  // ── markUploaded ──────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("markUploaded: 최초 호출 시 processingStatus가 UPLOADED로 설정된다")
+  void markUploaded_success() {
+    mediaFile.markUploaded();
+
+    assertThat(mediaFile.getProcessingStatus()).isEqualTo(ProcessingStatus.UPLOADED);
+  }
+
+  @Test
+  @DisplayName("markUploaded: 두 번째 호출 시 INVALID_MEDIA_STATE 예외가 발생한다")
+  void markUploaded_alreadySet_throwsException() {
+    mediaFile.markUploaded();
+
+    assertThatThrownBy(() -> mediaFile.markUploaded())
+        .isInstanceOf(CustomException.class)
+        .satisfies(ex -> assertThat(((CustomException) ex).getResultCode())
+            .isEqualTo(ResultCode.INVALID_MEDIA_STATE));
+  }
+
+  // ── markProcessing ────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("markProcessing: UPLOADED → PROCESSING 전이 성공")
+  void markProcessing_fromUploaded_success() {
+    mediaFile.markUploaded();
+    mediaFile.markProcessing();
+
+    assertThat(mediaFile.getProcessingStatus()).isEqualTo(ProcessingStatus.PROCESSING);
+  }
+
+  @Test
+  @DisplayName("markProcessing: null 상태에서 호출 시 INVALID_MEDIA_STATE 예외가 발생한다")
+  void markProcessing_fromNull_throwsException() {
+    assertThatThrownBy(() -> mediaFile.markProcessing())
+        .isInstanceOf(CustomException.class)
+        .satisfies(ex -> assertThat(((CustomException) ex).getResultCode())
+            .isEqualTo(ResultCode.INVALID_MEDIA_STATE));
+  }
+
+  // ── markProcessed ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("markProcessed: UPLOADED 상태에서 직접 성공 (processedAt 세팅)")
+  void markProcessed_fromUploaded_success() {
+    LocalDateTime now = LocalDateTime.now();
+    mediaFile.markUploaded();
+    mediaFile.markProcessed(now);
+
+    assertThat(mediaFile.getProcessingStatus()).isEqualTo(ProcessingStatus.PROCESSED);
+    assertThat(mediaFile.getProcessedAt()).isEqualTo(now);
+  }
+
+  @Test
+  @DisplayName("markProcessed: PROCESSING 상태에서도 성공한다")
+  void markProcessed_fromProcessing_success() {
+    LocalDateTime now = LocalDateTime.now();
+    mediaFile.markUploaded();
+    mediaFile.markProcessing();
+    mediaFile.markProcessed(now);
+
+    assertThat(mediaFile.getProcessingStatus()).isEqualTo(ProcessingStatus.PROCESSED);
+    assertThat(mediaFile.getProcessedAt()).isEqualTo(now);
+  }
+
+  @Test
+  @DisplayName("markProcessed: 이미 PROCESSED 상태에서 재호출 시 INVALID_MEDIA_STATE 예외가 발생한다")
+  void markProcessed_alreadyProcessed_throwsException() {
+    LocalDateTime now = LocalDateTime.now();
+    mediaFile.markUploaded();
+    mediaFile.markProcessed(now);
+
+    assertThatThrownBy(() -> mediaFile.markProcessed(now))
+        .isInstanceOf(CustomException.class)
+        .satisfies(ex -> assertThat(((CustomException) ex).getResultCode())
+            .isEqualTo(ResultCode.INVALID_MEDIA_STATE));
+  }
+
+  @Test
+  @DisplayName("markProcessed: 이전 failureReason을 null로 리셋한다")
+  void markProcessed_resetsFailureReason() {
+    // Builder로 UPLOADED 상태 + failureReason이 미리 세팅된 파일을 만든다
+    MediaFile mf = MediaFile.builder()
+        .mediaKey("test-key-2")
+        .processingStatus(ProcessingStatus.UPLOADED)
+        .failureReason("previous error")
+        .build();
+    assertThat(mf.getFailureReason()).isEqualTo("previous error");
+
+    mf.markProcessed(LocalDateTime.now());
+
+    assertThat(mf.getFailureReason()).isNull();
+    assertThat(mf.getProcessingStatus()).isEqualTo(ProcessingStatus.PROCESSED);
+  }
+
+  // ── markFailed ────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("markFailed: null 상태에서 호출 가능하고 reason이 저장된다")
+  void markFailed_fromNull_success() {
+    mediaFile.markFailed("timeout");
+
+    assertThat(mediaFile.getProcessingStatus()).isEqualTo(ProcessingStatus.FAILED);
+    assertThat(mediaFile.getFailureReason()).isEqualTo("timeout");
+  }
+
+  @Test
+  @DisplayName("markFailed: UPLOADED 상태에서 호출 가능하다")
+  void markFailed_fromUploaded_success() {
+    mediaFile.markUploaded();
+    mediaFile.markFailed("parse error");
+
+    assertThat(mediaFile.getProcessingStatus()).isEqualTo(ProcessingStatus.FAILED);
+    assertThat(mediaFile.getFailureReason()).isEqualTo("parse error");
+  }
+
+  @Test
+  @DisplayName("markFailed: PROCESSING 상태에서 호출 가능하다")
+  void markFailed_fromProcessing_success() {
+    mediaFile.markUploaded();
+    mediaFile.markProcessing();
+    mediaFile.markFailed("crash");
+
+    assertThat(mediaFile.getProcessingStatus()).isEqualTo(ProcessingStatus.FAILED);
+    assertThat(mediaFile.getFailureReason()).isEqualTo("crash");
+  }
+
+  @Test
+  @DisplayName("markFailed: PROCESSED 상태에서 호출 시 INVALID_MEDIA_STATE 예외가 발생한다")
+  void markFailed_fromProcessed_throwsException() {
+    mediaFile.markUploaded();
+    mediaFile.markProcessed(LocalDateTime.now());
+
+    assertThatThrownBy(() -> mediaFile.markFailed("too late"))
+        .isInstanceOf(CustomException.class)
+        .satisfies(ex -> assertThat(((CustomException) ex).getResultCode())
+            .isEqualTo(ResultCode.INVALID_MEDIA_STATE));
+  }
+}

--- a/src/test/java/com/triptyche/backend/domain/media/repository/MediaFileRepositoryTest.java
+++ b/src/test/java/com/triptyche/backend/domain/media/repository/MediaFileRepositoryTest.java
@@ -1,0 +1,152 @@
+package com.triptyche.backend.domain.media.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import com.triptyche.backend.domain.media.model.MediaFile;
+import com.triptyche.backend.domain.trip.model.PinPoint;
+import com.triptyche.backend.domain.trip.model.Trip;
+import com.triptyche.backend.domain.trip.model.TripStatus;
+import com.triptyche.backend.domain.user.model.User;
+import jakarta.persistence.EntityManagerFactory;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+class MediaFileRepositoryTest {
+
+    @Autowired
+    MediaFileRepository mediaFileRepository;
+
+    @Autowired
+    TestEntityManager tem;
+
+    @Autowired
+    EntityManagerFactory emf;
+
+    private User owner;
+    private Trip trip;
+    private Trip otherTrip;
+    private PinPoint pinPoint;
+
+    @BeforeEach
+    void setUp() {
+        owner = tem.persist(User.builder()
+                .userName("owner")
+                .userNickName("오너닉네임")
+                .userEmail("owner@test.com")
+                .provider("google")
+                .build());
+
+        trip = tem.persist(Trip.builder()
+                .user(owner)
+                .tripTitle("여행A")
+                .country("KR")
+                .startDate(LocalDate.of(2025, 1, 1))
+                .endDate(LocalDate.of(2025, 1, 10))
+                .hashtags("여행")
+                .status(TripStatus.CONFIRMED)
+                .build());
+
+        otherTrip = tem.persist(Trip.builder()
+                .user(owner)
+                .tripTitle("여행B")
+                .country("KR")
+                .startDate(LocalDate.of(2025, 2, 1))
+                .endDate(LocalDate.of(2025, 2, 10))
+                .hashtags("여행")
+                .status(TripStatus.CONFIRMED)
+                .build());
+
+        pinPoint = tem.persist(PinPoint.builder()
+                .trip(trip)
+                .latitude(37.5)
+                .longitude(127.0)
+                .build());
+
+        tem.flush();
+        tem.clear();
+    }
+
+    private MediaFile persistMediaFile(Trip t, PinPoint pp, String mediaKey) {
+        return tem.persist(MediaFile.builder()
+                .trip(t)
+                .pinPoint(pp)
+                .mediaKey(mediaKey)
+                .mediaType("image/jpeg")
+                .mediaLink("https://example.com/" + mediaKey)
+                .recordDate(LocalDateTime.of(2025, 1, 5, 12, 0))
+                .latitude(37.5)
+                .longitude(127.0)
+                .build());
+    }
+
+    private Statistics getStatistics() {
+        SessionFactory sf = emf.unwrap(SessionFactory.class);
+        sf.getStatistics().setStatisticsEnabled(true);
+        return sf.getStatistics();
+    }
+
+    @Nested
+    @DisplayName("findByTripTripIdWithPinPoint()")
+    class FindByTripTripIdWithPinPoint {
+
+        @Test
+        @DisplayName("주어진 tripId의 MediaFile들이 pinPoint까지 즉시 로딩됨 (N+1 없음)")
+        void pinPointFetchedWithoutExtraQuery() {
+            persistMediaFile(trip, pinPoint, "key1");
+            persistMediaFile(trip, pinPoint, "key2");
+            persistMediaFile(trip, pinPoint, "key3");
+            tem.flush();
+            tem.clear();
+
+            Statistics stats = getStatistics();
+            stats.clear();
+
+            List<MediaFile> results = mediaFileRepository.findByTripTripIdWithPinPoint(trip.getTripId());
+
+            long queryCountAfterLoad = stats.getPrepareStatementCount();
+
+            // pinPoint 접근 시 추가 쿼리 발생 없어야 함
+            assertThatNoException().isThrownBy(() ->
+                    results.forEach(m -> m.getPinPoint().getLatitude())
+            );
+
+            long queryCountAfterAccess = stats.getPrepareStatementCount();
+            assertThat(queryCountAfterAccess).isEqualTo(queryCountAfterLoad);
+            assertThat(results).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("다른 trip의 MediaFile은 결과에 포함되지 않음")
+        void otherTripRowsExcluded() {
+            PinPoint otherPinPoint = tem.persist(PinPoint.builder()
+                    .trip(otherTrip)
+                    .latitude(35.0)
+                    .longitude(129.0)
+                    .build());
+
+            persistMediaFile(trip, pinPoint, "trip-key1");
+            persistMediaFile(trip, pinPoint, "trip-key2");
+            persistMediaFile(otherTrip, otherPinPoint, "other-key1");
+            tem.flush();
+            tem.clear();
+
+            List<MediaFile> results = mediaFileRepository.findByTripTripIdWithPinPoint(trip.getTripId());
+
+            assertThat(results).hasSize(2);
+            assertThat(results).extracting(MediaFile::getMediaKey)
+                    .containsExactlyInAnyOrder("trip-key1", "trip-key2");
+        }
+    }
+}

--- a/src/test/java/com/triptyche/backend/domain/media/repository/MediaFileRepositoryTest.java
+++ b/src/test/java/com/triptyche/backend/domain/media/repository/MediaFileRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import com.triptyche.backend.domain.media.model.MediaFile;
+import com.triptyche.backend.domain.media.model.ProcessingStatus;
 import com.triptyche.backend.domain.trip.model.PinPoint;
 import com.triptyche.backend.domain.trip.model.Trip;
 import com.triptyche.backend.domain.trip.model.TripStatus;
@@ -95,6 +96,69 @@ class MediaFileRepositoryTest {
         SessionFactory sf = emf.unwrap(SessionFactory.class);
         sf.getStatistics().setStatisticsEnabled(true);
         return sf.getStatistics();
+    }
+
+    @Nested
+    @DisplayName("findOrphans()")
+    class FindOrphans {
+
+        private MediaFile persistOrphan(String mediaKey, LocalDateTime createdAt, ProcessingStatus status) {
+            MediaFile mf = MediaFile.builder()
+                    .trip(trip)
+                    .mediaKey(mediaKey)
+                    .tempKey("temp/" + mediaKey)
+                    .mediaType("image/jpeg")
+                    .processingStatus(status)
+                    .build();
+            MediaFile persisted = tem.persist(mf);
+            // @CreationTimestamp는 JPA insert 시 자동 설정되므로 JPQL로 createdAt을 직접 덮어씀
+            tem.getEntityManager()
+                    .createQuery("UPDATE MediaFile m SET m.createdAt = :ts WHERE m.mediaFileId = :id")
+                    .setParameter("ts", createdAt)
+                    .setParameter("id", persisted.getMediaFileId())
+                    .executeUpdate();
+            return persisted;
+        }
+
+        @Test
+        @DisplayName("threshold 이전 + status null → orphan으로 포함")
+        void includesNullStatusBeforeThreshold() {
+            LocalDateTime threshold = LocalDateTime.now();
+            persistOrphan("old-null", threshold.minusHours(7), null);
+            tem.flush();
+            tem.clear();
+
+            List<MediaFile> result = mediaFileRepository.findOrphans(threshold);
+
+            assertThat(result).extracting(MediaFile::getMediaKey)
+                    .containsExactly("old-null");
+        }
+
+        @Test
+        @DisplayName("threshold 이후 + status null → 아직 orphan 아님, 제외")
+        void excludesNullStatusAfterThreshold() {
+            LocalDateTime threshold = LocalDateTime.now();
+            persistOrphan("new-null", threshold.plusHours(1), null);
+            tem.flush();
+            tem.clear();
+
+            List<MediaFile> result = mediaFileRepository.findOrphans(threshold);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("threshold 이전 + status UPLOADED → 정상 흐름 진입, 제외")
+        void excludesUploadedStatusBeforeThreshold() {
+            LocalDateTime threshold = LocalDateTime.now();
+            persistOrphan("old-uploaded", threshold.minusHours(7), ProcessingStatus.UPLOADED);
+            tem.flush();
+            tem.clear();
+
+            List<MediaFile> result = mediaFileRepository.findOrphans(threshold);
+
+            assertThat(result).isEmpty();
+        }
     }
 
     @Nested

--- a/src/test/java/com/triptyche/backend/domain/media/scheduler/MediaOrphanCleanupExecutorTest.java
+++ b/src/test/java/com/triptyche/backend/domain/media/scheduler/MediaOrphanCleanupExecutorTest.java
@@ -1,0 +1,133 @@
+package com.triptyche.backend.domain.media.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.triptyche.backend.domain.media.event.MediaFilesS3DeleteRequestedEvent;
+import com.triptyche.backend.domain.media.model.MediaFile;
+import com.triptyche.backend.domain.media.repository.MediaFileRepository;
+import com.triptyche.backend.domain.trip.model.Trip;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class MediaOrphanCleanupExecutorTest {
+
+    @Mock
+    private MediaFileRepository mediaFileRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private MediaOrphanCleanupExecutor executor;
+
+    private MediaFile buildOrphan(String tempKey) {
+        Trip trip = Trip.builder()
+                .user(null)
+                .tripTitle("테스트여행")
+                .country("KR")
+                .startDate(LocalDate.of(2025, 1, 1))
+                .endDate(LocalDate.of(2025, 1, 10))
+                .hashtags("여행")
+                .build();
+
+        return MediaFile.builder()
+                .trip(trip)
+                .mediaKey("media-key-" + tempKey)
+                .tempKey(tempKey)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("orphan이 없는 경우")
+    class WhenNoOrphans {
+
+        @Test
+        @DisplayName("deleteAll과 이벤트 발행 없이 0을 반환한다")
+        void returnsZeroWithoutSideEffects() {
+            given(mediaFileRepository.findOrphans(any())).willReturn(List.of());
+
+            int result = executor.cleanup();
+
+            assertThat(result).isZero();
+            verify(mediaFileRepository, never()).deleteAll(any(Iterable.class));
+            verify(eventPublisher, never()).publishEvent(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("tempKey가 모두 채워진 orphan 3건")
+    class WhenThreeOrphansWithTempKeys {
+
+        @Test
+        @DisplayName("deleteAll 호출 + MediaFilesS3DeleteRequestedEvent에 3개 키 포함")
+        void deletesAllAndPublishesEventWithThreeKeys() {
+            List<MediaFile> orphans = List.of(
+                    buildOrphan("temp/a.jpg"),
+                    buildOrphan("temp/b.jpg"),
+                    buildOrphan("temp/c.jpg")
+            );
+            given(mediaFileRepository.findOrphans(any())).willReturn(orphans);
+
+            int result = executor.cleanup();
+
+            assertThat(result).isEqualTo(3);
+            verify(mediaFileRepository).deleteAll(orphans);
+            verify(eventPublisher).publishEvent(
+                    argThat((MediaFilesS3DeleteRequestedEvent event) ->
+                            event.mediaKeys().size() == 3
+                            && event.mediaKeys().containsAll(
+                                    List.of("temp/a.jpg", "temp/b.jpg", "temp/c.jpg"))
+                    )
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("tempKey가 null인 row가 포함된 경우")
+    class WhenSomeOrphansHaveNullTempKey {
+
+        @Test
+        @DisplayName("null tempKey는 S3 삭제 대상에서 제외된다")
+        void excludesNullTempKeysFromEvent() {
+            MediaFile withKey = buildOrphan("temp/exists.jpg");
+            MediaFile withoutKey = MediaFile.builder()
+                    .trip(Trip.builder()
+                            .user(null)
+                            .tripTitle("테스트여행")
+                            .country("KR")
+                            .startDate(LocalDate.of(2025, 1, 1))
+                            .endDate(LocalDate.of(2025, 1, 10))
+                            .hashtags("여행")
+                            .build())
+                    .mediaKey("media-key-no-temp")
+                    .tempKey(null)
+                    .build();
+            List<MediaFile> orphans = List.of(withKey, withoutKey);
+            given(mediaFileRepository.findOrphans(any())).willReturn(orphans);
+
+            int result = executor.cleanup();
+
+            assertThat(result).isEqualTo(2);
+            verify(mediaFileRepository).deleteAll(orphans);
+            verify(eventPublisher).publishEvent(
+                    argThat((MediaFilesS3DeleteRequestedEvent event) ->
+                            event.mediaKeys().equals(List.of("temp/exists.jpg"))
+                    )
+            );
+        }
+    }
+}

--- a/src/test/java/com/triptyche/backend/domain/media/service/MediaCommandServiceTest.java
+++ b/src/test/java/com/triptyche/backend/domain/media/service/MediaCommandServiceTest.java
@@ -1,0 +1,253 @@
+package com.triptyche.backend.domain.media.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.triptyche.backend.domain.media.dto.MediaUploadedRequest;
+import com.triptyche.backend.domain.media.dto.MediaUploadedResponse;
+import com.triptyche.backend.domain.media.event.MediaFileRegisteredEvent;
+import com.triptyche.backend.domain.media.model.MediaFile;
+import com.triptyche.backend.domain.media.model.ProcessingStatus;
+import com.triptyche.backend.domain.media.repository.MediaFileRepository;
+import com.triptyche.backend.domain.trip.model.PinPoint;
+import com.triptyche.backend.domain.trip.model.Trip;
+import com.triptyche.backend.domain.trip.service.PinPointService;
+import com.triptyche.backend.domain.trip.service.TripAccessGuard;
+import com.triptyche.backend.domain.user.model.User;
+import com.triptyche.backend.global.common.ResultCode;
+import com.triptyche.backend.global.exception.CustomException;
+import com.triptyche.backend.global.s3.S3KeyResolver;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class MediaCommandServiceTest {
+
+    @Mock
+    private MediaFileRepository mediaFileRepository;
+    @Mock
+    private PinPointService pinPointService;
+    @Mock
+    private S3KeyResolver s3KeyResolver;
+    @Mock
+    private TripAccessGuard tripAccessGuard;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private MediaCommandService mediaCommandService;
+
+    private static final String TRIP_KEY = "TRIP-KEY-001";
+    private static final Long TRIP_ID = 42L;
+    private static final Long USER_ID = 10L;
+    private static final Long OTHER_TRIP_ID = 99L;
+
+    private User user;
+    private Trip trip;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .userId(USER_ID)
+                .userName("테스터")
+                .userNickName("tester")
+                .userEmail("tester@example.com")
+                .provider("google")
+                .build();
+
+        trip = Trip.builder()
+                .tripId(TRIP_ID)
+                .tripTitle("테스트 여행")
+                .country("일본")
+                .user(user)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("markUploadedAndEnqueue()")
+    class MarkUploadedAndEnqueue {
+
+        @Test
+        @DisplayName("happy path: 2개 row → 응답 2건, status=UPLOADED, currentUrl/finalUrl 올바름")
+        void happyPath_twoItems_returnsCorrectResponse() {
+            // given
+            given(tripAccessGuard.validateAccessibleTripByKey(TRIP_KEY, user)).willReturn(trip);
+
+            PinPoint pinPoint = PinPoint.builder()
+                    .pinPointId(1L)
+                    .trip(trip)
+                    .latitude(37.5)
+                    .longitude(127.0)
+                    .build();
+
+            MediaFile mf1 = MediaFile.builder()
+                    .mediaFileId(101L)
+                    .trip(trip)
+                    .mediaType("image/webp")
+                    .mediaKey("processed/42/uuid1.webp")
+                    .tempKey("temp/42/uuid1.jpg")
+                    .finalKey("processed/42/uuid1.webp")
+                    .build();
+
+            MediaFile mf2 = MediaFile.builder()
+                    .mediaFileId(102L)
+                    .trip(trip)
+                    .mediaType("image/webp")
+                    .mediaKey("processed/42/uuid2.webp")
+                    .tempKey("temp/42/uuid2.jpg")
+                    .finalKey("processed/42/uuid2.webp")
+                    .build();
+
+            given(mediaFileRepository.findAllById(List.of(101L, 102L)))
+                    .willReturn(List.of(mf1, mf2));
+            given(pinPointService.findAllByTripId(TRIP_ID)).willReturn(List.of(pinPoint));
+            given(pinPointService.assignPinPoint(any(), any(), any(), any())).willReturn(pinPoint);
+            given(s3KeyResolver.buildUrl("temp/42/uuid1.jpg")).willReturn("https://s3.example.com/temp/42/uuid1.jpg");
+            given(s3KeyResolver.buildUrl("processed/42/uuid1.webp")).willReturn("https://s3.example.com/processed/42/uuid1.webp");
+            given(s3KeyResolver.buildUrl("temp/42/uuid2.jpg")).willReturn("https://s3.example.com/temp/42/uuid2.jpg");
+            given(s3KeyResolver.buildUrl("processed/42/uuid2.webp")).willReturn("https://s3.example.com/processed/42/uuid2.webp");
+
+            MediaUploadedRequest request = new MediaUploadedRequest(List.of(
+                    new MediaUploadedRequest.Item(101L, "2024-01-01T12:00:00", 37.5, 127.0),
+                    new MediaUploadedRequest.Item(102L, "2024-01-01T13:00:00", 37.5, 127.0)
+            ));
+
+            // when
+            MediaUploadedResponse response = mediaCommandService.markUploadedAndEnqueue(user, TRIP_KEY, request);
+
+            // then
+            assertThat(response.items()).hasSize(2);
+
+            MediaUploadedResponse.Item item1 = response.items().get(0);
+            assertThat(item1.mediaFileId()).isEqualTo(101L);
+            assertThat(item1.currentUrl()).isEqualTo("https://s3.example.com/temp/42/uuid1.jpg");
+            assertThat(item1.finalUrl()).isEqualTo("https://s3.example.com/processed/42/uuid1.webp");
+            assertThat(item1.status()).isEqualTo(ProcessingStatus.UPLOADED.name());
+
+            MediaUploadedResponse.Item item2 = response.items().get(1);
+            assertThat(item2.mediaFileId()).isEqualTo(102L);
+            assertThat(item2.status()).isEqualTo(ProcessingStatus.UPLOADED.name());
+        }
+
+        @Test
+        @DisplayName("미존재 mediaFileId → MEDIA_FILE_NOT_FOUND 예외")
+        void unknownMediaFileId_throwsMediaFileNotFound() {
+            // given
+            given(tripAccessGuard.validateAccessibleTripByKey(TRIP_KEY, user)).willReturn(trip);
+            // findAllById returns only 1 of 2 requested
+            MediaFile mf1 = MediaFile.builder()
+                    .mediaFileId(101L)
+                    .trip(trip)
+                    .tempKey("temp/42/uuid1.jpg")
+                    .finalKey("processed/42/uuid1.webp")
+                    .mediaKey("processed/42/uuid1.webp")
+                    .build();
+            given(mediaFileRepository.findAllById(List.of(101L, 999L)))
+                    .willReturn(List.of(mf1));
+
+            MediaUploadedRequest request = new MediaUploadedRequest(List.of(
+                    new MediaUploadedRequest.Item(101L, "2024-01-01T12:00:00", 37.5, 127.0),
+                    new MediaUploadedRequest.Item(999L, "2024-01-01T13:00:00", 37.5, 127.0)
+            ));
+
+            // when / then
+            assertThatThrownBy(() -> mediaCommandService.markUploadedAndEnqueue(user, TRIP_KEY, request))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getResultCode())
+                    .isEqualTo(ResultCode.MEDIA_FILE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("다른 trip의 row → ACCESS_DENIED 예외")
+        void mediaFileBelongsToDifferentTrip_throwsAccessDenied() {
+            // given
+            given(tripAccessGuard.validateAccessibleTripByKey(TRIP_KEY, user)).willReturn(trip);
+
+            Trip otherTrip = Trip.builder()
+                    .tripId(OTHER_TRIP_ID)
+                    .tripTitle("남의 여행")
+                    .country("프랑스")
+                    .user(user)
+                    .build();
+
+            MediaFile mf = MediaFile.builder()
+                    .mediaFileId(101L)
+                    .trip(otherTrip)
+                    .tempKey("temp/99/uuid1.jpg")
+                    .finalKey("processed/99/uuid1.webp")
+                    .mediaKey("processed/99/uuid1.webp")
+                    .build();
+
+            given(mediaFileRepository.findAllById(List.of(101L))).willReturn(List.of(mf));
+
+            MediaUploadedRequest request = new MediaUploadedRequest(List.of(
+                    new MediaUploadedRequest.Item(101L, "2024-01-01T12:00:00", 37.5, 127.0)
+            ));
+
+            // when / then
+            assertThatThrownBy(() -> mediaCommandService.markUploadedAndEnqueue(user, TRIP_KEY, request))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getResultCode())
+                    .isEqualTo(ResultCode.ACCESS_DENIED);
+        }
+
+        @Test
+        @DisplayName("v2 이벤트 발행 검증: flow=v2, tempKey/finalKey 포함")
+        void publishesV2Event() {
+            // given
+            given(tripAccessGuard.validateAccessibleTripByKey(TRIP_KEY, user)).willReturn(trip);
+
+            PinPoint pinPoint = PinPoint.builder()
+                    .pinPointId(1L)
+                    .trip(trip)
+                    .latitude(37.5)
+                    .longitude(127.0)
+                    .build();
+
+            MediaFile mf = MediaFile.builder()
+                    .mediaFileId(101L)
+                    .trip(trip)
+                    .mediaType("image/webp")
+                    .mediaKey("processed/42/uuid1.webp")
+                    .tempKey("temp/42/uuid1.jpg")
+                    .finalKey("processed/42/uuid1.webp")
+                    .build();
+
+            given(mediaFileRepository.findAllById(List.of(101L))).willReturn(List.of(mf));
+            given(pinPointService.findAllByTripId(TRIP_ID)).willReturn(List.of(pinPoint));
+            given(pinPointService.assignPinPoint(any(), any(), any(), any())).willReturn(pinPoint);
+            given(s3KeyResolver.buildUrl(any())).willReturn("https://s3.example.com/any");
+
+            MediaUploadedRequest request = new MediaUploadedRequest(List.of(
+                    new MediaUploadedRequest.Item(101L, "2024-01-01T12:00:00", 37.5, 127.0)
+            ));
+
+            // when
+            mediaCommandService.markUploadedAndEnqueue(user, TRIP_KEY, request);
+
+            // then
+            ArgumentCaptor<MediaFileRegisteredEvent> captor =
+                    ArgumentCaptor.forClass(MediaFileRegisteredEvent.class);
+            verify(eventPublisher).publishEvent(captor.capture());
+
+            MediaFileRegisteredEvent published = captor.getValue();
+            assertThat(published.flow()).isEqualTo("v2");
+            assertThat(published.tempKey()).isEqualTo("temp/42/uuid1.jpg");
+            assertThat(published.finalKey()).isEqualTo("processed/42/uuid1.webp");
+            assertThat(published.originalKey()).isNull();
+            assertThat(published.mediaFileId()).isEqualTo(101L);
+        }
+    }
+}

--- a/src/test/java/com/triptyche/backend/domain/media/service/MediaPresignServiceTest.java
+++ b/src/test/java/com/triptyche/backend/domain/media/service/MediaPresignServiceTest.java
@@ -1,0 +1,269 @@
+package com.triptyche.backend.domain.media.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.triptyche.backend.domain.media.dto.PresignedUrlCreateRequest;
+import com.triptyche.backend.domain.media.dto.PresignedUrlCreateRequest.FileInfo;
+import com.triptyche.backend.domain.media.dto.PresignedUrlResponse;
+import com.triptyche.backend.domain.media.dto.PresignedUrlResponse.PresignedUrl;
+import com.triptyche.backend.domain.media.model.MediaFile;
+import com.triptyche.backend.domain.media.repository.MediaFileRepository;
+import com.triptyche.backend.domain.trip.model.Trip;
+import com.triptyche.backend.domain.trip.service.TripAccessGuard;
+import com.triptyche.backend.domain.user.model.User;
+import com.triptyche.backend.global.s3.PresignedURLService;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MediaPresignServiceTest {
+
+    @Mock
+    private TripAccessGuard tripAccessGuard;
+
+    @Mock
+    private PresignedURLService presignedURLService;
+
+    @Mock
+    private MediaFileRepository mediaFileRepository;
+
+    @InjectMocks
+    private MediaPresignService mediaPresignService;
+
+    private static final String TRIP_KEY = "TRIP-KEY-001";
+    private static final Long TRIP_ID = 42L;
+
+    private User user;
+    private Trip trip;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .userId(10L)
+                .userName("테스터")
+                .userNickName("tester")
+                .userEmail("tester@example.com")
+                .provider("google")
+                .build();
+
+        trip = Trip.builder()
+                .tripId(TRIP_ID)
+                .tripTitle("테스트 여행")
+                .country("일본")
+                .user(user)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("issuePutUrls()")
+    class IssuePutUrls {
+
+        @Test
+        @DisplayName("N개 파일에 대해 tempKey/finalKey 다른 UUID로 생성, 응답 N건 반환")
+        void issuePutUrls_multipleFiles_returnsNResults() {
+            // given
+            given(tripAccessGuard.validateAccessibleTripByKey(TRIP_KEY, user)).willReturn(trip);
+
+            AtomicLong idSeq = new AtomicLong(100L);
+            given(mediaFileRepository.save(any(MediaFile.class))).willAnswer(inv -> {
+                MediaFile mf = inv.getArgument(0);
+                // simulate JPA id assignment via reflection is not needed — we use a stub
+                MediaFile saved = MediaFile.builder()
+                        .trip(mf.getTrip())
+                        .mediaType(mf.getMediaType())
+                        .mediaKey(mf.getMediaKey())
+                        .tempKey(mf.getTempKey())
+                        .finalKey(mf.getFinalKey())
+                        .mediaFileId(idSeq.getAndIncrement())
+                        .build();
+                return saved;
+            });
+            given(presignedURLService.generatePresignedPutUrl(any(), any(Duration.class)))
+                    .willAnswer(inv -> "https://s3.example.com/put?key=" + inv.getArgument(0));
+
+            PresignedUrlCreateRequest request = new PresignedUrlCreateRequest(List.of(
+                    new FileInfo("photo1.jpg"),
+                    new FileInfo("photo2.PNG")
+            ));
+
+            // when
+            PresignedUrlResponse response = mediaPresignService.issuePutUrls(user, TRIP_KEY, request);
+
+            // then
+            assertThat(response.presignedUrls()).hasSize(2);
+
+            PresignedUrl first = response.presignedUrls().get(0);
+            PresignedUrl second = response.presignedUrls().get(1);
+
+            // tempKey and finalKey are different for each file
+            assertThat(first.tempKey()).isNotEqualTo(second.tempKey());
+            assertThat(first.finalKey()).isNotEqualTo(second.finalKey());
+
+            // fileKey == tempKey (backward compat)
+            assertThat(first.fileKey()).isEqualTo(first.tempKey());
+            assertThat(second.fileKey()).isEqualTo(second.tempKey());
+
+            // tempKey starts with temp/, finalKey starts with processed/
+            assertThat(first.tempKey()).startsWith("temp/");
+            assertThat(first.finalKey()).startsWith("processed/");
+            assertThat(first.finalKey()).endsWith(".webp");
+
+            // presignedPutUrl uses tempKey
+            assertThat(first.presignedPutUrl()).contains(first.tempKey());
+
+            // mediaFileId assigned
+            assertThat(first.mediaFileId()).isNotNull();
+            assertThat(second.mediaFileId()).isNotNull();
+            assertThat(first.mediaFileId()).isNotEqualTo(second.mediaFileId());
+        }
+
+        @Test
+        @DisplayName("mediaFileRepository.save()가 N회 호출되고 저장된 MediaFile의 필드가 올바르다")
+        void issuePutUrls_savesMediaFileWithCorrectFields() {
+            // given
+            given(tripAccessGuard.validateAccessibleTripByKey(TRIP_KEY, user)).willReturn(trip);
+
+            AtomicLong idSeq = new AtomicLong(1L);
+            given(mediaFileRepository.save(any(MediaFile.class))).willAnswer(inv -> {
+                MediaFile mf = inv.getArgument(0);
+                return MediaFile.builder()
+                        .mediaFileId(idSeq.getAndIncrement())
+                        .trip(mf.getTrip())
+                        .mediaType(mf.getMediaType())
+                        .mediaKey(mf.getMediaKey())
+                        .tempKey(mf.getTempKey())
+                        .finalKey(mf.getFinalKey())
+                        .build();
+            });
+            given(presignedURLService.generatePresignedPutUrl(any(), any(Duration.class)))
+                    .willReturn("https://s3.example.com/put");
+
+            PresignedUrlCreateRequest request = new PresignedUrlCreateRequest(List.of(
+                    new FileInfo("img.jpg"),
+                    new FileInfo("img2.jpg"),
+                    new FileInfo("img3.jpg")
+            ));
+
+            // when
+            mediaPresignService.issuePutUrls(user, TRIP_KEY, request);
+
+            // then: save called 3 times
+            ArgumentCaptor<MediaFile> captor = ArgumentCaptor.forClass(MediaFile.class);
+            verify(mediaFileRepository, times(3)).save(captor.capture());
+
+            List<MediaFile> saved = captor.getAllValues();
+            for (MediaFile mf : saved) {
+                assertThat(mf.getTrip()).isEqualTo(trip);
+                assertThat(mf.getMediaType()).isEqualTo("image/webp");
+                assertThat(mf.getTempKey()).startsWith("temp/" + TRIP_ID + "/");
+                assertThat(mf.getFinalKey()).startsWith("processed/" + TRIP_ID + "/");
+                assertThat(mf.getFinalKey()).endsWith(".webp");
+                // mediaKey == finalKey
+                assertThat(mf.getMediaKey()).isEqualTo(mf.getFinalKey());
+                // pinPoint is null (not set at presign time)
+                assertThat(mf.getPinPoint()).isNull();
+            }
+        }
+
+        @Test
+        @DisplayName("presignedURLService.generatePresignedPutUrl이 tempKey로 호출된다")
+        void issuePutUrls_callsPresignedUrlServiceWithTempKey() {
+            // given
+            given(tripAccessGuard.validateAccessibleTripByKey(TRIP_KEY, user)).willReturn(trip);
+
+            AtomicLong idSeq = new AtomicLong(1L);
+            given(mediaFileRepository.save(any(MediaFile.class))).willAnswer(inv -> {
+                MediaFile mf = inv.getArgument(0);
+                return MediaFile.builder()
+                        .mediaFileId(idSeq.getAndIncrement())
+                        .trip(mf.getTrip())
+                        .mediaType(mf.getMediaType())
+                        .mediaKey(mf.getMediaKey())
+                        .tempKey(mf.getTempKey())
+                        .finalKey(mf.getFinalKey())
+                        .build();
+            });
+            given(presignedURLService.generatePresignedPutUrl(any(), any(Duration.class)))
+                    .willReturn("https://s3.example.com/put");
+
+            PresignedUrlCreateRequest request = new PresignedUrlCreateRequest(List.of(
+                    new FileInfo("photo.jpg")
+            ));
+
+            // when
+            PresignedUrlResponse response = mediaPresignService.issuePutUrls(user, TRIP_KEY, request);
+
+            // then
+            String usedTempKey = response.presignedUrls().get(0).tempKey();
+            verify(presignedURLService).generatePresignedPutUrl(eq(usedTempKey), any(Duration.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("extractExtension() — private static method via issuePutUrls 통합 검증")
+    class ExtractExtension {
+
+        @BeforeEach
+        void stubCommon() {
+            given(tripAccessGuard.validateAccessibleTripByKey(TRIP_KEY, user)).willReturn(trip);
+            given(mediaFileRepository.save(any(MediaFile.class))).willAnswer(inv -> {
+                MediaFile mf = inv.getArgument(0);
+                return MediaFile.builder()
+                        .mediaFileId(1L)
+                        .trip(mf.getTrip())
+                        .mediaType(mf.getMediaType())
+                        .mediaKey(mf.getMediaKey())
+                        .tempKey(mf.getTempKey())
+                        .finalKey(mf.getFinalKey())
+                        .build();
+            });
+            given(presignedURLService.generatePresignedPutUrl(any(), any(Duration.class)))
+                    .willReturn("https://s3.example.com/put");
+        }
+
+        @Test
+        @DisplayName("foo.JPG → tempKey에 .jpg 포함")
+        void extractExtension_uppercaseJpg_normalized() {
+            PresignedUrlCreateRequest request = new PresignedUrlCreateRequest(List.of(new FileInfo("foo.JPG")));
+
+            PresignedUrlResponse response = mediaPresignService.issuePutUrls(user, TRIP_KEY, request);
+
+            assertThat(response.presignedUrls().get(0).tempKey()).endsWith(".jpg");
+        }
+
+        @Test
+        @DisplayName("확장자 없는 파일명 → tempKey에 .jpg(기본값) 포함")
+        void extractExtension_noExtension_defaultsToJpg() {
+            PresignedUrlCreateRequest request = new PresignedUrlCreateRequest(List.of(new FileInfo("foo")));
+
+            PresignedUrlResponse response = mediaPresignService.issuePutUrls(user, TRIP_KEY, request);
+
+            assertThat(response.presignedUrls().get(0).tempKey()).endsWith(".jpg");
+        }
+
+        @Test
+        @DisplayName("파일명이 '.'으로 끝나는 경우 → tempKey에 .jpg(기본값) 포함")
+        void extractExtension_trailingDot_defaultsToJpg() {
+            PresignedUrlCreateRequest request = new PresignedUrlCreateRequest(List.of(new FileInfo("foo.")));
+
+            PresignedUrlResponse response = mediaPresignService.issuePutUrls(user, TRIP_KEY, request);
+
+            assertThat(response.presignedUrls().get(0).tempKey()).endsWith(".jpg");
+        }
+    }
+}

--- a/src/test/java/com/triptyche/backend/domain/media/service/MediaProcessingServiceTest.java
+++ b/src/test/java/com/triptyche/backend/domain/media/service/MediaProcessingServiceTest.java
@@ -1,0 +1,186 @@
+package com.triptyche.backend.domain.media.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.triptyche.backend.domain.media.event.ImageProcessedEvent;
+import com.triptyche.backend.domain.media.event.ImageProcessingFailedEvent;
+import com.triptyche.backend.domain.media.model.MediaFile;
+import com.triptyche.backend.domain.media.model.ProcessingStatus;
+import com.triptyche.backend.domain.media.repository.MediaFileRepository;
+import com.triptyche.backend.domain.trip.model.Trip;
+import com.triptyche.backend.domain.user.model.User;
+import com.triptyche.backend.global.common.ResultCode;
+import com.triptyche.backend.global.exception.CustomException;
+import com.triptyche.backend.global.s3.S3KeyResolver;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class MediaProcessingServiceTest {
+
+  @Mock
+  private MediaFileRepository mediaFileRepository;
+
+  @Mock
+  private S3KeyResolver s3KeyResolver;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
+
+  @InjectMocks
+  private MediaProcessingService mediaProcessingService;
+
+  private static final Long MEDIA_FILE_ID = 1L;
+  private static final Long USER_ID = 10L;
+  private static final String FINAL_KEY = "processed/42/abc.webp";
+  private static final String FINAL_URL = "https://cdn.example.com/processed/42/abc.webp";
+  private static final LocalDateTime PROCESSED_AT = LocalDateTime.of(2024, 6, 1, 12, 0);
+
+  private MediaFile buildMediaFile(ProcessingStatus status) {
+    User user = User.builder()
+        .userId(USER_ID)
+        .userName("테스터")
+        .userNickName("tester")
+        .userEmail("tester@example.com")
+        .provider("google")
+        .build();
+    Trip trip = Trip.builder()
+        .tripTitle("테스트 여행")
+        .country("일본")
+        .user(user)
+        .build();
+    MediaFile mf = MediaFile.builder()
+        .trip(trip)
+        .mediaKey("originals/tripKey/file.jpg")
+        .mediaLink("https://cdn.example.com/originals/tripKey/file.jpg")
+        .processingStatus(status)
+        .build();
+    return mf;
+  }
+
+  @Nested
+  @DisplayName("applyProcessedResult()")
+  class ApplyProcessedResult {
+
+    @Test
+    @DisplayName("PROCESSING 상태의 MediaFile을 PROCESSED로 전이하고 ImageProcessedEvent를 발행한다")
+    void applyProcessedResult_givenProcessingFile_transitionsToProcessedAndPublishesEvent() {
+      MediaFile mf = buildMediaFile(ProcessingStatus.PROCESSING);
+      given(mediaFileRepository.findById(MEDIA_FILE_ID)).willReturn(Optional.of(mf));
+      given(s3KeyResolver.buildUrl(FINAL_KEY)).willReturn(FINAL_URL);
+
+      mediaProcessingService.applyProcessedResult(MEDIA_FILE_ID, FINAL_KEY, PROCESSED_AT);
+
+      assertThat(mf.getProcessingStatus()).isEqualTo(ProcessingStatus.PROCESSED);
+      assertThat(mf.getMediaLink()).isEqualTo(FINAL_URL);
+
+      ArgumentCaptor<ImageProcessedEvent> captor = ArgumentCaptor.forClass(ImageProcessedEvent.class);
+      verify(eventPublisher).publishEvent(captor.capture());
+      ImageProcessedEvent event = captor.getValue();
+      assertThat(event.mediaFileId()).isEqualTo(MEDIA_FILE_ID);
+      assertThat(event.userId()).isEqualTo(USER_ID);
+      assertThat(event.finalUrl()).isEqualTo(FINAL_URL);
+      assertThat(event.processedAt()).isEqualTo(PROCESSED_AT);
+    }
+
+    @Test
+    @DisplayName("UPLOADED 상태의 MediaFile도 PROCESSED로 전이할 수 있다")
+    void applyProcessedResult_givenUploadedFile_transitionsToProcessed() {
+      MediaFile mf = buildMediaFile(ProcessingStatus.UPLOADED);
+      given(mediaFileRepository.findById(MEDIA_FILE_ID)).willReturn(Optional.of(mf));
+      given(s3KeyResolver.buildUrl(FINAL_KEY)).willReturn(FINAL_URL);
+
+      mediaProcessingService.applyProcessedResult(MEDIA_FILE_ID, FINAL_KEY, PROCESSED_AT);
+
+      assertThat(mf.getProcessingStatus()).isEqualTo(ProcessingStatus.PROCESSED);
+      verify(eventPublisher).publishEvent(any(ImageProcessedEvent.class));
+    }
+
+    @Test
+    @DisplayName("이미 PROCESSED 상태이면 멱등하게 처리되고 이벤트는 발행되지 않는다")
+    void applyProcessedResult_givenAlreadyProcessedFile_isIdempotent() {
+      MediaFile mf = buildMediaFile(ProcessingStatus.PROCESSED);
+      given(mediaFileRepository.findById(MEDIA_FILE_ID)).willReturn(Optional.of(mf));
+
+      mediaProcessingService.applyProcessedResult(MEDIA_FILE_ID, FINAL_KEY, PROCESSED_AT);
+
+      verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 mediaFileId이면 MEDIA_FILE_NOT_FOUND 예외가 발생한다")
+    void applyProcessedResult_givenMissingMediaFile_throwsNotFound() {
+      given(mediaFileRepository.findById(MEDIA_FILE_ID)).willReturn(Optional.empty());
+
+      assertThatThrownBy(() -> mediaProcessingService.applyProcessedResult(MEDIA_FILE_ID, FINAL_KEY, PROCESSED_AT))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getResultCode())
+          .isEqualTo(ResultCode.MEDIA_FILE_NOT_FOUND);
+
+      verify(eventPublisher, never()).publishEvent(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("applyFailedResult()")
+  class ApplyFailedResult {
+
+    private static final String REASON = "처리 타임아웃";
+
+    @Test
+    @DisplayName("PROCESSING 상태의 MediaFile을 FAILED로 전이하고 ImageProcessingFailedEvent를 발행한다")
+    void applyFailedResult_givenProcessingFile_transitionsToFailedAndPublishesEvent() {
+      MediaFile mf = buildMediaFile(ProcessingStatus.PROCESSING);
+      given(mediaFileRepository.findById(MEDIA_FILE_ID)).willReturn(Optional.of(mf));
+
+      mediaProcessingService.applyFailedResult(MEDIA_FILE_ID, REASON);
+
+      assertThat(mf.getProcessingStatus()).isEqualTo(ProcessingStatus.FAILED);
+
+      ArgumentCaptor<ImageProcessingFailedEvent> captor = ArgumentCaptor.forClass(ImageProcessingFailedEvent.class);
+      verify(eventPublisher).publishEvent(captor.capture());
+      ImageProcessingFailedEvent event = captor.getValue();
+      assertThat(event.mediaFileId()).isEqualTo(MEDIA_FILE_ID);
+      assertThat(event.userId()).isEqualTo(USER_ID);
+      assertThat(event.reason()).isEqualTo(REASON);
+    }
+
+    @Test
+    @DisplayName("이미 PROCESSED 상태이면 멱등하게 처리되고 이벤트는 발행되지 않는다")
+    void applyFailedResult_givenAlreadyProcessedFile_isIdempotent() {
+      MediaFile mf = buildMediaFile(ProcessingStatus.PROCESSED);
+      given(mediaFileRepository.findById(MEDIA_FILE_ID)).willReturn(Optional.of(mf));
+
+      mediaProcessingService.applyFailedResult(MEDIA_FILE_ID, REASON);
+
+      verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 mediaFileId이면 MEDIA_FILE_NOT_FOUND 예외가 발생한다")
+    void applyFailedResult_givenMissingMediaFile_throwsNotFound() {
+      given(mediaFileRepository.findById(MEDIA_FILE_ID)).willReturn(Optional.empty());
+
+      assertThatThrownBy(() -> mediaProcessingService.applyFailedResult(MEDIA_FILE_ID, REASON))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getResultCode())
+          .isEqualTo(ResultCode.MEDIA_FILE_NOT_FOUND);
+
+      verify(eventPublisher, never()).publishEvent(any());
+    }
+  }
+}

--- a/src/test/java/com/triptyche/backend/domain/media/service/MediaQueryServiceTest.java
+++ b/src/test/java/com/triptyche/backend/domain/media/service/MediaQueryServiceTest.java
@@ -141,7 +141,7 @@ class MediaQueryServiceTest {
 
             assertThat(response.items()).hasSize(1);
             UploadStatusResponse.Item item = response.items().get(0);
-            assertThat(item.status()).isEqualTo("LEGACY");
+            assertThat(item.status()).isEqualTo(UploadStatusResponse.LEGACY_STATUS);
             assertThat(item.currentUrl()).isEqualTo("https://s3/bucket/legacy-link");
             assertThat(item.finalUrl()).isEqualTo("https://s3/bucket/legacy-link");
             assertThat(item.failureReason()).isNull();

--- a/src/test/java/com/triptyche/backend/domain/media/service/MediaQueryServiceTest.java
+++ b/src/test/java/com/triptyche/backend/domain/media/service/MediaQueryServiceTest.java
@@ -1,0 +1,224 @@
+package com.triptyche.backend.domain.media.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.triptyche.backend.domain.media.dto.UploadStatusResponse;
+import com.triptyche.backend.domain.media.model.MediaFile;
+import com.triptyche.backend.domain.media.model.ProcessingStatus;
+import com.triptyche.backend.domain.media.repository.MediaFileRepository;
+import com.triptyche.backend.domain.trip.model.Trip;
+import com.triptyche.backend.domain.trip.service.TripAccessGuard;
+import com.triptyche.backend.domain.user.model.User;
+import com.triptyche.backend.global.s3.S3KeyResolver;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MediaQueryServiceTest {
+
+    @Mock
+    private MediaFileRepository mediaFileRepository;
+    @Mock
+    private TripAccessGuard tripAccessGuard;
+    @Mock
+    private UnlocatedMediaCacheService unlocatedMediaCacheService;
+    @Mock
+    private S3KeyResolver s3KeyResolver;
+
+    @InjectMocks
+    private MediaQueryService mediaQueryService;
+
+    private static final String TRIP_KEY = "TRIP-KEY-001";
+    private static final Long TRIP_ID = 42L;
+    private static final Long USER_ID = 10L;
+
+    private User user;
+    private Trip trip;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .userId(USER_ID)
+                .userName("테스터")
+                .userNickName("tester")
+                .userEmail("tester@example.com")
+                .provider("google")
+                .build();
+
+        trip = Trip.builder()
+                .tripId(TRIP_ID)
+                .tripTitle("테스트 여행")
+                .country("일본")
+                .user(user)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("getUploadStatus()")
+    class GetUploadStatus {
+
+        @Test
+        @DisplayName("다양한 status가 섞인 4건 → 각각 올바른 status 문자열 매핑")
+        void mixedStatusRows_returnCorrectStatusStrings() {
+            MediaFile uploaded = MediaFile.builder()
+                    .mediaFileId(1L)
+                    .trip(trip)
+                    .mediaKey("key1")
+                    .tempKey("temp/42/uuid1.jpg")
+                    .processingStatus(ProcessingStatus.UPLOADED)
+                    .mediaLink("https://s3/bucket/legacy1")
+                    .build();
+
+            MediaFile processing = MediaFile.builder()
+                    .mediaFileId(2L)
+                    .trip(trip)
+                    .mediaKey("key2")
+                    .tempKey("temp/42/uuid2.jpg")
+                    .processingStatus(ProcessingStatus.PROCESSING)
+                    .mediaLink("https://s3/bucket/legacy2")
+                    .build();
+
+            MediaFile processed = MediaFile.builder()
+                    .mediaFileId(3L)
+                    .trip(trip)
+                    .mediaKey("key3")
+                    .tempKey("temp/42/uuid3.jpg")
+                    .finalKey("processed/42/uuid3.webp")
+                    .processingStatus(ProcessingStatus.PROCESSED)
+                    .processedAt(LocalDateTime.of(2025, 1, 5, 12, 0))
+                    .mediaLink("https://s3/bucket/processed3")
+                    .build();
+
+            MediaFile failed = MediaFile.builder()
+                    .mediaFileId(4L)
+                    .trip(trip)
+                    .mediaKey("key4")
+                    .tempKey("temp/42/uuid4.jpg")
+                    .processingStatus(ProcessingStatus.FAILED)
+                    .failureReason("변환 실패")
+                    .mediaLink("https://s3/bucket/legacy4")
+                    .build();
+
+            given(tripAccessGuard.validateAccessibleTripByKey(TRIP_KEY, user)).willReturn(trip);
+            given(mediaFileRepository.findByTripTripIdWithPinPoint(TRIP_ID))
+                    .willReturn(List.of(uploaded, processing, processed, failed));
+            given(s3KeyResolver.buildUrl("temp/42/uuid1.jpg")).willReturn("https://s3/bucket/temp/42/uuid1.jpg");
+            given(s3KeyResolver.buildUrl("temp/42/uuid2.jpg")).willReturn("https://s3/bucket/temp/42/uuid2.jpg");
+            given(s3KeyResolver.buildUrl("temp/42/uuid3.jpg")).willReturn("https://s3/bucket/temp/42/uuid3.jpg");
+            given(s3KeyResolver.buildUrl("processed/42/uuid3.webp")).willReturn("https://s3/bucket/processed/42/uuid3.webp");
+            given(s3KeyResolver.buildUrl("temp/42/uuid4.jpg")).willReturn("https://s3/bucket/temp/42/uuid4.jpg");
+
+            UploadStatusResponse response = mediaQueryService.getUploadStatus(user, TRIP_KEY);
+
+            assertThat(response.items()).hasSize(4);
+            assertThat(response.items()).extracting(UploadStatusResponse.Item::status)
+                    .containsExactly("UPLOADED", "PROCESSING", "PROCESSED", "FAILED");
+        }
+
+        @Test
+        @DisplayName("processingStatus null → status='LEGACY', currentUrl/finalUrl은 mediaLink 폴백")
+        void nullProcessingStatus_returnsLegacyStatus() {
+            MediaFile legacy = MediaFile.builder()
+                    .mediaFileId(10L)
+                    .trip(trip)
+                    .mediaKey("legacy-key")
+                    .mediaLink("https://s3/bucket/legacy-link")
+                    .build();
+
+            given(tripAccessGuard.validateAccessibleTripByKey(TRIP_KEY, user)).willReturn(trip);
+            given(mediaFileRepository.findByTripTripIdWithPinPoint(TRIP_ID)).willReturn(List.of(legacy));
+
+            UploadStatusResponse response = mediaQueryService.getUploadStatus(user, TRIP_KEY);
+
+            assertThat(response.items()).hasSize(1);
+            UploadStatusResponse.Item item = response.items().get(0);
+            assertThat(item.status()).isEqualTo("LEGACY");
+            assertThat(item.currentUrl()).isEqualTo("https://s3/bucket/legacy-link");
+            assertThat(item.finalUrl()).isEqualTo("https://s3/bucket/legacy-link");
+            assertThat(item.failureReason()).isNull();
+            assertThat(item.processedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("FAILED row → failureReason 포함")
+        void failedRow_includesFailureReason() {
+            MediaFile failed = MediaFile.builder()
+                    .mediaFileId(20L)
+                    .trip(trip)
+                    .mediaKey("fail-key")
+                    .tempKey("temp/42/fail.jpg")
+                    .processingStatus(ProcessingStatus.FAILED)
+                    .failureReason("변환 오류")
+                    .mediaLink("https://s3/bucket/fail-link")
+                    .build();
+
+            given(tripAccessGuard.validateAccessibleTripByKey(TRIP_KEY, user)).willReturn(trip);
+            given(mediaFileRepository.findByTripTripIdWithPinPoint(TRIP_ID)).willReturn(List.of(failed));
+            given(s3KeyResolver.buildUrl("temp/42/fail.jpg")).willReturn("https://s3/bucket/temp/42/fail.jpg");
+
+            UploadStatusResponse response = mediaQueryService.getUploadStatus(user, TRIP_KEY);
+
+            UploadStatusResponse.Item item = response.items().get(0);
+            assertThat(item.status()).isEqualTo("FAILED");
+            assertThat(item.failureReason()).isEqualTo("변환 오류");
+        }
+
+        @Test
+        @DisplayName("PROCESSED row → failureReason=null, processedAt 매핑")
+        void processedRow_nullFailureReasonAndProcessedAtMapped() {
+            LocalDateTime processedAt = LocalDateTime.of(2025, 3, 10, 9, 30);
+            MediaFile processed = MediaFile.builder()
+                    .mediaFileId(30L)
+                    .trip(trip)
+                    .mediaKey("proc-key")
+                    .tempKey("temp/42/proc.jpg")
+                    .finalKey("processed/42/proc.webp")
+                    .processingStatus(ProcessingStatus.PROCESSED)
+                    .processedAt(processedAt)
+                    .mediaLink("https://s3/bucket/proc-link")
+                    .build();
+
+            given(tripAccessGuard.validateAccessibleTripByKey(TRIP_KEY, user)).willReturn(trip);
+            given(mediaFileRepository.findByTripTripIdWithPinPoint(TRIP_ID)).willReturn(List.of(processed));
+            given(s3KeyResolver.buildUrl("temp/42/proc.jpg")).willReturn("https://s3/bucket/temp/42/proc.jpg");
+            given(s3KeyResolver.buildUrl("processed/42/proc.webp")).willReturn("https://s3/bucket/processed/42/proc.webp");
+
+            UploadStatusResponse response = mediaQueryService.getUploadStatus(user, TRIP_KEY);
+
+            UploadStatusResponse.Item item = response.items().get(0);
+            assertThat(item.status()).isEqualTo("PROCESSED");
+            assertThat(item.failureReason()).isNull();
+            assertThat(item.processedAt()).isEqualTo(processedAt.toString());
+            assertThat(item.finalUrl()).isEqualTo("https://s3/bucket/processed/42/proc.webp");
+        }
+
+        @Test
+        @DisplayName("tempKey/finalKey 모두 null인 LEGACY row → currentUrl/finalUrl 모두 mediaLink 폴백")
+        void noKeys_fallbackToMediaLink() {
+            MediaFile noKeys = MediaFile.builder()
+                    .mediaFileId(40L)
+                    .trip(trip)
+                    .mediaKey("no-keys")
+                    .mediaLink("https://s3/bucket/original-link")
+                    .build();
+
+            given(tripAccessGuard.validateAccessibleTripByKey(TRIP_KEY, user)).willReturn(trip);
+            given(mediaFileRepository.findByTripTripIdWithPinPoint(TRIP_ID)).willReturn(List.of(noKeys));
+
+            UploadStatusResponse response = mediaQueryService.getUploadStatus(user, TRIP_KEY);
+
+            UploadStatusResponse.Item item = response.items().get(0);
+            assertThat(item.currentUrl()).isEqualTo("https://s3/bucket/original-link");
+            assertThat(item.finalUrl()).isEqualTo("https://s3/bucket/original-link");
+        }
+    }
+}

--- a/src/test/java/com/triptyche/backend/domain/trip/model/TripTest.java
+++ b/src/test/java/com/triptyche/backend/domain/trip/model/TripTest.java
@@ -37,14 +37,29 @@ class TripTest {
     }
 
     @Test
-    @DisplayName("DRAFT가 아닌 상태에서 호출하면 예외 발생")
-    void fail_when_not_draft() throws Exception {
+    @DisplayName("IMAGES_UPLOADED 상태에서 다시 호출해도 idempotent — 상태 유지")
+    void idempotent_when_already_uploaded() throws Exception {
       //given
       Trip trip = createTrip(TripStatus.IMAGES_UPLOADED);
 
-      //when & then
-      assertThatThrownBy(trip::markImagesUploaded)
-              .isInstanceOf(CustomException.class);
+      //when
+      trip.markImagesUploaded();
+
+      //then
+      assertThat(trip.getStatus()).isEqualTo(TripStatus.IMAGES_UPLOADED);
+    }
+
+    @Test
+    @DisplayName("CONFIRMED 상태에서 호출해도 idempotent — DRAFT로 강등되지 않음")
+    void idempotent_when_confirmed() throws Exception {
+      //given
+      Trip trip = createTrip(TripStatus.CONFIRMED);
+
+      //when
+      trip.markImagesUploaded();
+
+      //then
+      assertThat(trip.getStatus()).isEqualTo(TripStatus.CONFIRMED);
     }
   }
 

--- a/src/test/java/com/triptyche/backend/domain/trip/service/TripCommandServiceTest.java
+++ b/src/test/java/com/triptyche/backend/domain/trip/service/TripCommandServiceTest.java
@@ -137,17 +137,17 @@ class TripCommandServiceTest {
     }
 
     @Test
-    @DisplayName("DRAFT가 아닌 상태의 여행에 요청하면 INVALID_TRIP_STATE 예외가 발생한다")
-    void markImagesUploaded_givenNonDraftTrip_throwsInvalidTripState() {
+    @DisplayName("이미 IMAGES_UPLOADED 상태인 여행에 다시 요청해도 idempotent — 상태 유지")
+    void markImagesUploaded_givenAlreadyUploadedTrip_idempotent() {
       // given
       Trip trip = createTrip(TripStatus.IMAGES_UPLOADED, owner);
       given(tripAccessGuard.validateAccessibleTripByKey(TEST_TRIP_KEY, owner)).willReturn(trip);
 
-      // when & then
-      assertThatThrownBy(() -> tripCommandService.markImagesUploaded(owner, TEST_TRIP_KEY))
-              .isInstanceOf(CustomException.class)
-              .extracting(e -> ((CustomException) e).getResultCode())
-              .isEqualTo(ResultCode.INVALID_TRIP_STATE);
+      // when
+      tripCommandService.markImagesUploaded(owner, TEST_TRIP_KEY);
+
+      // then
+      assertThat(trip.getStatus()).isEqualTo(TripStatus.IMAGES_UPLOADED);
     }
 
     @Test

--- a/src/test/java/com/triptyche/backend/global/redis/ImageProcessingPublisherTest.java
+++ b/src/test/java/com/triptyche/backend/global/redis/ImageProcessingPublisherTest.java
@@ -1,0 +1,98 @@
+package com.triptyche.backend.global.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.triptyche.backend.domain.media.event.MediaFileRegisteredEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StreamOperations;
+
+@ExtendWith(MockitoExtension.class)
+class ImageProcessingPublisherTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private StreamOperations<String, Object, Object> streamOperations;
+
+    @InjectMocks
+    private ImageProcessingPublisher imageProcessingPublisher;
+
+    @BeforeEach
+    void setUp() {
+        given(redisTemplate.opsForStream()).willReturn(streamOperations);
+    }
+
+    @Nested
+    @DisplayName("v1 이벤트")
+    class V1Event {
+
+        @Test
+        @DisplayName("payload에 mediaFileId + originalKey만 포함, flow 키 없음")
+        void v1Event_payloadContainsMediaFileIdAndOriginalKeyOnly() {
+            // given
+            MediaFileRegisteredEvent event = MediaFileRegisteredEvent.v1(42L, "originals/TRIP-KEY/photo.jpg");
+
+            // when
+            imageProcessingPublisher.publish(event);
+
+            // then
+            ArgumentCaptor<MapRecord<String, Object, Object>> captor =
+                    ArgumentCaptor.forClass(MapRecord.class);
+            verify(streamOperations).add(captor.capture());
+
+            MapRecord<String, Object, Object> record = captor.getValue();
+            assertThat(record.getValue()).containsKey("mediaFileId");
+            assertThat(record.getValue()).containsKey("originalKey");
+            assertThat(record.getValue()).doesNotContainKey("flow");
+            assertThat(record.getValue()).doesNotContainKey("tempKey");
+            assertThat(record.getValue()).doesNotContainKey("finalKey");
+            assertThat(record.getValue().get("mediaFileId")).isEqualTo("42");
+            assertThat(record.getValue().get("originalKey")).isEqualTo("originals/TRIP-KEY/photo.jpg");
+        }
+    }
+
+    @Nested
+    @DisplayName("v2 이벤트")
+    class V2Event {
+
+        @Test
+        @DisplayName("payload에 mediaFileId + tempKey + finalKey + flow=v2 포함")
+        void v2Event_payloadContainsAllV2Fields() {
+            // given
+            MediaFileRegisteredEvent event = MediaFileRegisteredEvent.v2(
+                    77L, "temp/42/uuid1.jpg", "processed/42/uuid1.webp");
+
+            // when
+            imageProcessingPublisher.publish(event);
+
+            // then
+            ArgumentCaptor<MapRecord<String, Object, Object>> captor =
+                    ArgumentCaptor.forClass(MapRecord.class);
+            verify(streamOperations).add(captor.capture());
+
+            MapRecord<String, Object, Object> record = captor.getValue();
+            assertThat(record.getValue()).containsKey("mediaFileId");
+            assertThat(record.getValue()).containsKey("tempKey");
+            assertThat(record.getValue()).containsKey("finalKey");
+            assertThat(record.getValue()).containsKey("flow");
+            assertThat(record.getValue()).doesNotContainKey("originalKey");
+            assertThat(record.getValue().get("mediaFileId")).isEqualTo("77");
+            assertThat(record.getValue().get("tempKey")).isEqualTo("temp/42/uuid1.jpg");
+            assertThat(record.getValue().get("finalKey")).isEqualTo("processed/42/uuid1.webp");
+            assertThat(record.getValue().get("flow")).isEqualTo("v2");
+        }
+    }
+}

--- a/src/test/java/com/triptyche/backend/global/redis/MediaProcessedStreamConsumerTest.java
+++ b/src/test/java/com/triptyche/backend/global/redis/MediaProcessedStreamConsumerTest.java
@@ -1,0 +1,138 @@
+package com.triptyche.backend.global.redis;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.triptyche.backend.domain.media.service.MediaProcessingService;
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.stream.MapRecord;
+
+@ExtendWith(MockitoExtension.class)
+class MediaProcessedStreamConsumerTest {
+
+  @Mock
+  private MediaProcessingService mediaProcessingService;
+
+  @InjectMocks
+  private MediaProcessedStreamConsumer consumer;
+
+  private static final String STREAM_KEY = "media-processed-stream";
+
+  @Nested
+  @DisplayName("성공 메시지 처리")
+  class SuccessMessage {
+
+    @Test
+    @DisplayName("finalKey/processedAt 필드를 포함한 메시지는 applyProcessedResult를 호출한다")
+    void onMessage_givenSuccessPayload_callsApplyProcessedResult() {
+      MapRecord<String, String, String> record = MapRecord.create(STREAM_KEY, Map.of(
+          "mediaFileId", "1",
+          "finalKey", "processed/42/abc.webp",
+          "processedAt", "2024-06-01T12:00:00"
+      ));
+
+      consumer.onMessage(record);
+
+      verify(mediaProcessingService).applyProcessedResult(
+          eq(1L),
+          eq("processed/42/abc.webp"),
+          eq(LocalDateTime.of(2024, 6, 1, 12, 0, 0))
+      );
+      verify(mediaProcessingService, never()).applyFailedResult(any(), any());
+    }
+  }
+
+  @Nested
+  @DisplayName("실패 메시지 처리")
+  class FailureMessage {
+
+    @Test
+    @DisplayName("status=FAILED 필드를 포함한 메시지는 applyFailedResult를 호출한다")
+    void onMessage_givenFailedPayload_callsApplyFailedResult() {
+      MapRecord<String, String, String> record = MapRecord.create(STREAM_KEY, Map.of(
+          "mediaFileId", "2",
+          "status", "FAILED",
+          "reason", "처리 타임아웃"
+      ));
+
+      consumer.onMessage(record);
+
+      verify(mediaProcessingService).applyFailedResult(eq(2L), eq("처리 타임아웃"));
+      verify(mediaProcessingService, never()).applyProcessedResult(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("reason 필드 없는 실패 메시지는 'unknown'으로 fallback한다")
+    void onMessage_givenFailedPayloadWithoutReason_usesUnknownFallback() {
+      MapRecord<String, String, String> record = MapRecord.create(STREAM_KEY, Map.of(
+          "mediaFileId", "3",
+          "status", "FAILED"
+      ));
+
+      consumer.onMessage(record);
+
+      verify(mediaProcessingService).applyFailedResult(eq(3L), eq("unknown"));
+    }
+  }
+
+  @Nested
+  @DisplayName("잘못된 페이로드 처리")
+  class InvalidPayload {
+
+    @Test
+    @DisplayName("mediaFileId가 없는 메시지는 서비스를 호출하지 않고 예외를 던지지 않는다")
+    void onMessage_givenMissingMediaFileId_doesNotCallServiceAndDoesNotThrow() {
+      MapRecord<String, String, String> record = MapRecord.create(STREAM_KEY, Map.of(
+          "finalKey", "processed/42/abc.webp",
+          "processedAt", "2024-06-01T12:00:00"
+      ));
+
+      consumer.onMessage(record);
+
+      verify(mediaProcessingService, never()).applyProcessedResult(any(), any(), any());
+      verify(mediaProcessingService, never()).applyFailedResult(any(), any());
+    }
+
+    @Test
+    @DisplayName("mediaFileId가 숫자가 아닌 메시지는 서비스를 호출하지 않고 예외를 던지지 않는다")
+    void onMessage_givenNonNumericMediaFileId_doesNotCallServiceAndDoesNotThrow() {
+      MapRecord<String, String, String> record = MapRecord.create(STREAM_KEY, Map.of(
+          "mediaFileId", "not-a-number",
+          "finalKey", "processed/42/abc.webp",
+          "processedAt", "2024-06-01T12:00:00"
+      ));
+
+      consumer.onMessage(record);
+
+      verify(mediaProcessingService, never()).applyProcessedResult(any(), any(), any());
+      verify(mediaProcessingService, never()).applyFailedResult(any(), any());
+    }
+
+    @Test
+    @DisplayName("서비스에서 예외가 발생해도 onMessage 밖으로 예외가 새지 않는다")
+    void onMessage_givenServiceThrows_doesNotPropagateException() {
+      MapRecord<String, String, String> record = MapRecord.create(STREAM_KEY, Map.of(
+          "mediaFileId", "99",
+          "finalKey", "processed/42/abc.webp",
+          "processedAt", "2024-06-01T12:00:00"
+      ));
+
+      org.mockito.Mockito.doThrow(new RuntimeException("DB 오류"))
+          .when(mediaProcessingService)
+          .applyProcessedResult(any(), any(), any());
+
+      // 예외가 전파되지 않아야 함
+      consumer.onMessage(record);
+    }
+  }
+}

--- a/src/test/java/com/triptyche/backend/global/s3/S3KeyResolverTest.java
+++ b/src/test/java/com/triptyche/backend/global/s3/S3KeyResolverTest.java
@@ -1,0 +1,100 @@
+package com.triptyche.backend.global.s3;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class S3KeyResolverTest {
+
+    // buildTempKey
+    @Test
+    void buildTempKey_basicJpg() {
+        assertThat(S3KeyResolver.buildTempKey(42L, "abc-123", "jpg"))
+                .isEqualTo("temp/42/abc-123.jpg");
+    }
+
+    @Test
+    void buildTempKey_stripLeadingDot() {
+        // 점만 제거, 대소문자 유지
+        assertThat(S3KeyResolver.buildTempKey(42L, "abc-123", ".JPG"))
+                .isEqualTo("temp/42/abc-123.JPG");
+    }
+
+    @Test
+    void buildTempKey_nullExtension_defaultsToJpg() {
+        assertThat(S3KeyResolver.buildTempKey(42L, "u", null))
+                .isEqualTo("temp/42/u.jpg");
+    }
+
+    @Test
+    void buildTempKey_blankExtension_defaultsToJpg() {
+        assertThat(S3KeyResolver.buildTempKey(42L, "u", ""))
+                .isEqualTo("temp/42/u.jpg");
+    }
+
+    // buildFinalKey
+    @Test
+    void buildFinalKey_alwaysWebp() {
+        assertThat(S3KeyResolver.buildFinalKey(42L, "abc-123"))
+                .isEqualTo("processed/42/abc-123.webp");
+    }
+
+    // isTempKey
+    @Test
+    void isTempKey_trueForTempPrefix() {
+        assertThat(S3KeyResolver.isTempKey("temp/x.jpg")).isTrue();
+    }
+
+    @Test
+    void isTempKey_falseForOtherPrefix() {
+        assertThat(S3KeyResolver.isTempKey("originals/x.jpg")).isFalse();
+    }
+
+    @Test
+    void isTempKey_falseForNull() {
+        assertThat(S3KeyResolver.isTempKey(null)).isFalse();
+    }
+
+    // isFinalKey
+    @Test
+    void isFinalKey_trueForProcessedPrefix() {
+        assertThat(S3KeyResolver.isFinalKey("processed/x.webp")).isTrue();
+    }
+
+    @Test
+    void isFinalKey_falseForOtherPrefix() {
+        assertThat(S3KeyResolver.isFinalKey("temp/x.jpg")).isFalse();
+    }
+
+    // swapTempToFinalKey
+    @Test
+    void swapTempToFinalKey_normalCase() {
+        assertThat(S3KeyResolver.swapTempToFinalKey("temp/42/abc.jpg"))
+                .isEqualTo("processed/42/abc.webp");
+    }
+
+    @Test
+    void swapTempToFinalKey_extensionIgnored() {
+        assertThat(S3KeyResolver.swapTempToFinalKey("temp/42/abc.JPEG"))
+                .isEqualTo("processed/42/abc.webp");
+    }
+
+    @Test
+    void swapTempToFinalKey_nonTempPrefix_returnsNull() {
+        assertThat(S3KeyResolver.swapTempToFinalKey("originals/42/abc.jpg")).isNull();
+    }
+
+    @Test
+    void swapTempToFinalKey_noSlash_returnsNull() {
+        assertThat(S3KeyResolver.swapTempToFinalKey("temp/onlyfile.jpg")).isNull();
+    }
+
+    // sanity check for existing methods
+    @Test
+    void buildOriginalKey_sanity() {
+        assertThat(S3KeyResolver.buildOriginalKey("trip-1", "photo.jpg"))
+                .isEqualTo("originals/trip-1/photo.jpg");
+        assertThat(S3KeyResolver.isOriginalKey("originals/trip-1/photo.jpg")).isTrue();
+        assertThat(S3KeyResolver.isOriginalKey("seed/photo.jpg")).isFalse();
+    }
+}

--- a/src/test/java/com/triptyche/backend/global/websocket/StompTopicAuthInterceptorTest.java
+++ b/src/test/java/com/triptyche/backend/global/websocket/StompTopicAuthInterceptorTest.java
@@ -1,0 +1,159 @@
+package com.triptyche.backend.global.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.triptyche.backend.domain.user.model.User;
+import com.triptyche.backend.domain.user.repository.UserRepository;
+import java.security.Principal;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+@ExtendWith(MockitoExtension.class)
+class StompTopicAuthInterceptorTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @InjectMocks
+  private StompTopicAuthInterceptor interceptor;
+
+  private Message<?> buildMessage(StompCommand command, String destination, Principal principal) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(command);
+    accessor.setDestination(destination);
+    accessor.setUser(principal);
+    accessor.setSessionId("test-session");
+    return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+  }
+
+  private Principal principalOf(String name) {
+    return () -> name;
+  }
+
+  @Nested
+  @DisplayName("SUBSCRIBE /topic/media-processed/{userId}")
+  class MediaProcessedSubscription {
+
+    @Test
+    @DisplayName("principal name의 email이 userId와 일치하면 통과한다")
+    void subscribe_givenMatchingUser_passes() {
+      // given
+      long userId = 42L;
+      String email = "user@example.com";
+      User user = User.builder()
+              .userId(userId)
+              .userName("testUser")
+              .userEmail(email)
+              .provider("google")
+              .build();
+      given(userRepository.findByUserEmail(email)).willReturn(Optional.of(user));
+      Message<?> message = buildMessage(StompCommand.SUBSCRIBE, "/topic/media-processed/42", principalOf(email));
+
+      // when
+      Message<?> result = interceptor.preSend(message, null);
+
+      // then
+      assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("principal의 email이 다른 userId를 가지면 MessageDeliveryException을 던진다")
+    void subscribe_givenMismatchedUserId_throwsException() {
+      // given
+      String email = "other@example.com";
+      User user = User.builder()
+              .userId(99L)
+              .userName("otherUser")
+              .userEmail(email)
+              .provider("google")
+              .build();
+      given(userRepository.findByUserEmail(email)).willReturn(Optional.of(user));
+      Message<?> message = buildMessage(StompCommand.SUBSCRIBE, "/topic/media-processed/42", principalOf(email));
+
+      // when & then
+      assertThatThrownBy(() -> interceptor.preSend(message, null))
+              .isInstanceOf(MessageDeliveryException.class)
+              .hasMessage("forbidden topic subscription");
+    }
+
+    @Test
+    @DisplayName("destination의 userId가 숫자가 아니면 MessageDeliveryException을 던진다")
+    void subscribe_givenNonNumericUserId_throwsException() {
+      // given
+      Message<?> message = buildMessage(StompCommand.SUBSCRIBE, "/topic/media-processed/abc", principalOf("user@example.com"));
+
+      // when & then
+      assertThatThrownBy(() -> interceptor.preSend(message, null))
+              .isInstanceOf(MessageDeliveryException.class)
+              .hasMessage("invalid topic");
+    }
+
+    @Test
+    @DisplayName("principal이 null이면 MessageDeliveryException을 던진다")
+    void subscribe_givenNullPrincipal_throwsException() {
+      // given
+      Message<?> message = buildMessage(StompCommand.SUBSCRIBE, "/topic/media-processed/42", null);
+
+      // when & then
+      assertThatThrownBy(() -> interceptor.preSend(message, null))
+              .isInstanceOf(MessageDeliveryException.class)
+              .hasMessage("forbidden topic subscription");
+    }
+  }
+
+  @Nested
+  @DisplayName("다른 토픽 또는 다른 커맨드는 검증 없이 통과한다")
+  class NonMediaProcessedTopics {
+
+    @Test
+    @DisplayName("SUBSCRIBE /topic/share-notifications/{userId} — prefix가 달라 검증 생략, 통과")
+    void subscribe_givenShareNotificationsTopic_passes() {
+      // given — principal/userRepository 설정 없이도 통과해야 함
+      Message<?> message = buildMessage(StompCommand.SUBSCRIBE, "/topic/share-notifications/42", principalOf("user@example.com"));
+
+      // when
+      Message<?> result = interceptor.preSend(message, null);
+
+      // then
+      assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("SEND 커맨드는 검증 없이 통과한다")
+    void send_command_passes() {
+      // given
+      Message<?> message = buildMessage(StompCommand.SEND, "/topic/media-processed/42", principalOf("user@example.com"));
+
+      // when
+      Message<?> result = interceptor.preSend(message, null);
+
+      // then
+      assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("CONNECT 커맨드는 검증 없이 통과한다")
+    void connect_command_passes() {
+      // given
+      Message<?> message = buildMessage(StompCommand.CONNECT, null, principalOf("user@example.com"));
+
+      // when
+      Message<?> result = interceptor.preSend(message, null);
+
+      // then
+      assertThat(result).isNotNull();
+    }
+  }
+}


### PR DESCRIPTION
## 📌 변경 사항 개요

`.jpg → .webp` 변환 race로 인한 **FE 캐시 URL 404방지.
`temp/`·`processed/` 키 분리 + `MediaFile` 상태머신 + Python 워커 ↔ BE 양방향 Stream + STOMP 푸시 + REST 동기화.

## 🛠 주요 변경 사항

1. **[도메인]** `MediaFile`에 `ProcessingStatus`(UPLOADED/PROCESSING/PROCESSED/FAILED) 상태머신 + `tempKey`/`finalKey`/`createdAt`/`failureReason` 필드 + `markXxx` 도메인 메서드
2. **[API]** `POST /images-uploaded` (신규), `GET /upload-status` (신규), `POST /presigned-url` 응답 확장 — `mediaFileId`/`tempKey`/`finalKey` + 사전 INSERT
3. **[Stream]** Python 완료 신호 수신용 `media-processed-stream` BE 컨슈머 + `ImageProcessingPublisher`에 `flow=v2` 분기
4. **[STOMP]** `/topic/media-processed/{userId}` 권한 인터셉터 + 발행 리스너 (`@TransactionalEventListener(AFTER_COMMIT)`)
5. **[Worker]** `image-worker/main.py` v1/v2 분기 — v2는 결과 발행만, DB UPDATE/원본 삭제 제거 (S3 Lifecycle 위임), DLQ 진입 시 FAILED emit
6. **[스케줄러]** orphan presigned row 6시간 간격 클린업

