### PR TITLE
fix(media): orphan cleanup이 v1 legacy row를 삭제하지 않도록 영구 방어

### DIFF
--- a/src/main/java/com/triptyche/backend/domain/media/model/ProcessingStatus.java
+++ b/src/main/java/com/triptyche/backend/domain/media/model/ProcessingStatus.java
@@ -1,6 +1,8 @@
 package com.triptyche.backend.domain.media.model;
 
 public enum ProcessingStatus {
+  // v1 흐름에서 생성된 legacy 데이터. cleanup 대상에서 영구 제외.
+  LEGACY,
   UPLOADED,
   PROCESSING,
   PROCESSED,

--- a/src/main/java/com/triptyche/backend/domain/media/repository/MediaFileRepository.java
+++ b/src/main/java/com/triptyche/backend/domain/media/repository/MediaFileRepository.java
@@ -119,6 +119,7 @@ public interface MediaFileRepository extends JpaRepository<MediaFile, Long> {
   @Query("""
           SELECT m FROM MediaFile m
           WHERE m.processingStatus IS NULL
+            AND m.tempKey IS NOT NULL
             AND m.createdAt < :threshold
           """)
   List<MediaFile> findOrphans(@Param("threshold") LocalDateTime threshold);

--- a/src/main/java/com/triptyche/backend/domain/media/scheduler/MediaOrphanCleanupScheduler.java
+++ b/src/main/java/com/triptyche/backend/domain/media/scheduler/MediaOrphanCleanupScheduler.java
@@ -18,6 +18,9 @@ public class MediaOrphanCleanupScheduler {
       int deleted = executor.cleanup();
       if (deleted > 0) {
         log.info("[MEDIA_ORPHAN_CLEANUP] 삭제 완료 — count={}", deleted);
+        if (deleted > 50) {
+          log.warn("[MEDIA_ORPHAN_CLEANUP] 대량 삭제 감지 — count={} (anomaly threshold: 50)", deleted);
+        }
       }
     } catch (Exception e) {
       log.error("[MEDIA_ORPHAN_CLEANUP] 실패", e);

--- a/src/main/java/com/triptyche/backend/domain/media/service/MediaQueryService.java
+++ b/src/main/java/com/triptyche/backend/domain/media/service/MediaQueryService.java
@@ -109,7 +109,7 @@ public class MediaQueryService {
             mf.getMediaFileId(),
             mf.getTempKey() != null ? s3KeyResolver.buildUrl(mf.getTempKey()) : mf.getMediaLink(),
             mf.getFinalKey() != null ? s3KeyResolver.buildUrl(mf.getFinalKey()) : mf.getMediaLink(),
-            mf.getProcessingStatus() != null ? mf.getProcessingStatus().name() : UploadStatusResponse.LEGACY_STATUS,
+            mf.getProcessingStatus().name(),
             mf.getProcessedAt() != null ? mf.getProcessedAt().toString() : null,
             mf.getProcessingStatus() == ProcessingStatus.FAILED ? mf.getFailureReason() : null
         ))

--- a/src/test/java/com/triptyche/backend/domain/media/repository/MediaFileRepositoryTest.java
+++ b/src/test/java/com/triptyche/backend/domain/media/repository/MediaFileRepositoryTest.java
@@ -103,10 +103,15 @@ class MediaFileRepositoryTest {
     class FindOrphans {
 
         private MediaFile persistOrphan(String mediaKey, LocalDateTime createdAt, ProcessingStatus status) {
+            return persistRow(mediaKey, "temp/" + mediaKey, createdAt, status);
+        }
+
+        private MediaFile persistRow(String mediaKey, String tempKey, LocalDateTime createdAt,
+                ProcessingStatus status) {
             MediaFile mf = MediaFile.builder()
                     .trip(trip)
                     .mediaKey(mediaKey)
-                    .tempKey("temp/" + mediaKey)
+                    .tempKey(tempKey)
                     .mediaType("image/jpeg")
                     .processingStatus(status)
                     .build();
@@ -118,6 +123,46 @@ class MediaFileRepositoryTest {
                     .setParameter("id", persisted.getMediaFileId())
                     .executeUpdate();
             return persisted;
+        }
+
+        @Test
+        @DisplayName("v1 legacy row(tempKey=null, status=LEGACY)는 cleanup 대상에서 제외")
+        void excludesLegacyStatusRowWithoutTempKey() {
+            LocalDateTime threshold = LocalDateTime.now();
+            persistRow("v1-legacy", null, threshold.minusHours(7), ProcessingStatus.LEGACY);
+            tem.flush();
+            tem.clear();
+
+            List<MediaFile> result = mediaFileRepository.findOrphans(threshold);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("v1 row(tempKey=null, status=null)도 tempKey 가드로 제외 (Defense in Depth)")
+        void excludesNullStatusRowWithoutTempKey() {
+            LocalDateTime threshold = LocalDateTime.now();
+            persistRow("v1-null", null, threshold.minusHours(7), null);
+            tem.flush();
+            tem.clear();
+
+            List<MediaFile> result = mediaFileRepository.findOrphans(threshold);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("v2 orphan(tempKey 채워짐, status=null, threshold 이전)은 cleanup 대상으로 포함")
+        void includesV2OrphanWithTempKey() {
+            LocalDateTime threshold = LocalDateTime.now();
+            persistRow("v2-orphan", "temp/v2-orphan", threshold.minusHours(7), null);
+            tem.flush();
+            tem.clear();
+
+            List<MediaFile> result = mediaFileRepository.findOrphans(threshold);
+
+            assertThat(result).extracting(MediaFile::getMediaKey)
+                    .containsExactly("v2-orphan");
         }
 
         @Test

--- a/src/test/java/com/triptyche/backend/domain/media/service/MediaQueryServiceTest.java
+++ b/src/test/java/com/triptyche/backend/domain/media/service/MediaQueryServiceTest.java
@@ -125,12 +125,13 @@ class MediaQueryServiceTest {
         }
 
         @Test
-        @DisplayName("processingStatus null → status='LEGACY', currentUrl/finalUrl은 mediaLink 폴백")
-        void nullProcessingStatus_returnsLegacyStatus() {
+        @DisplayName("processingStatus LEGACY → status='LEGACY', currentUrl/finalUrl은 mediaLink 폴백")
+        void legacyProcessingStatus_returnsLegacyStatus() {
             MediaFile legacy = MediaFile.builder()
                     .mediaFileId(10L)
                     .trip(trip)
                     .mediaKey("legacy-key")
+                    .processingStatus(ProcessingStatus.LEGACY)
                     .mediaLink("https://s3/bucket/legacy-link")
                     .build();
 
@@ -208,6 +209,7 @@ class MediaQueryServiceTest {
                     .mediaFileId(40L)
                     .trip(trip)
                     .mediaKey("no-keys")
+                    .processingStatus(ProcessingStatus.LEGACY)
                     .mediaLink("https://s3/bucket/original-link")
                     .build();
 


### PR DESCRIPTION
## 배경 (운영 사고)

`ALTER TABLE`로 v2 흐름 컬럼(`temp_key`, `final_key`, `processing_status`, `created_at`)을 추가할 때 `created_at`이 `DEFAULT CURRENT_TIMESTAMP`로 정의되어, 기존 v1 row 전체의 `created_at`이 ALTER 실행 시각으로 일괄 채워졌습니다.

6시간 뒤 `MediaOrphanCleanupScheduler` cron이 실행되며 `findOrphans`(`processing_status IS NULL AND created_at < threshold`)가 v1 row 전체(2373개)를 cleanup 대상으로 매칭해 삭제하는 사고가 발생했습니다. (binlog PITR로 2363개 복구, 10개는 trip이 죽어 FK violation으로 INSERT 실패 — 의도된 안전망)

## 원인

v1 row의 `processing_status NULL`이 두 의미를 섞고 있었습니다:
- **legacy**: v2 흐름 이전 데이터
- **orphan**: v2 흐름에서 아직 처리되지 않은 미완성 업로드

`findOrphans`가 둘을 구분하지 못한 것이 사고의 본질입니다.

## 변경 (NULL의 모호함 → enum 명시성 + 이중 안전망)

- `ProcessingStatus`에 `LEGACY` 값 추가 (첫 번째 값, 시간순 의미상 v2 이전). 데이터 자체가 의도를 명시.
- `MediaQueryService.getUploadStatus()`의 NULL fallback 제거, enum 경로로 단순화. `UploadStatusResponse.LEGACY_STATUS` 상수는 FE 계약 호환 위해 유지 (`LEGACY.name()` == `"LEGACY"`).
- `MediaFileRepository.findOrphans()`에 `AND m.tempKey IS NOT NULL` 가드 추가 — v1 row는 tempKey가 영원히 NULL이라 누군가 status를 NULL로 되돌려도 한 번 더 차단 (Defense in Depth).
- `MediaOrphanCleanupScheduler`에 대량 삭제(`>50`건) 감지 WARN 로그 추가.
- 단위 테스트 3종 추가: v1 legacy(temp=null, LEGACY) 제외 / v1 null(temp=null, null) 제외 / v2 orphan(temp 채워짐, null) 포함.

## ⚠️ 배포 전 선행 작업

이 코드는 **기존 v1 row의 `processing_status`를 `LEGACY`로 UPDATE하는 마이그레이션**이 선행됨을 전제합니다. 마이그레이션 없이 배포하면 v1 row 조회 시 `getUploadStatus()`에서 NPE가 발생합니다.

## Test plan

- [x] `./gradlew compileJava`
- [x] `./gradlew test` — 196 tests passed
- [ ] 운영 DB v1 row `LEGACY` UPDATE 마이그레이션 적용 확인